### PR TITLE
Skip corrupt image files correctly

### DIFF
--- a/keogram.cpp
+++ b/keogram.cpp
@@ -48,6 +48,11 @@ int main(int argc, char *argv[])
     for (size_t f = 0; f < files.gl_pathc; f++)
     {
         cv::Mat image = cv::imread(files.gl_pathv[f], cv::IMREAD_UNCHANGED);
+        if (!image.data)
+        {
+            std::cout << "Error reading file " << basename(files.gl_pathv[f]) << std::endl;
+            continue;
+        }
 
         std::cout << "[" << f + 1 << "/" << files.gl_pathc << "] " << basename(files.gl_pathv[f]) << std::endl;
 

--- a/startrails.cpp
+++ b/startrails.cpp
@@ -56,6 +56,11 @@ int main(int argc, char *argv[])
     for (size_t f = 0; f < files.gl_pathc; f++)
     {
         cv::Mat image = cv::imread(files.gl_pathv[f], cv::IMREAD_UNCHANGED);
+        if (!image.data)
+        {
+            std::cout << "Error reading file " << basename(files.gl_pathv[f]) << std::endl;
+            continue;
+        }
 
         cv::Scalar mean_scalar = cv::mean(image);
         double mean;


### PR DESCRIPTION
Noticed that if I stop the capture process during the night that causes some empty files which then later crashed the keogram and startrail processes with OpenCV exception.  So skip those files and continue with the rest.