### PR TITLE
Systemd unit file

### DIFF
--- a/allsky.service
+++ b/allsky.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=All Sky Camera
+After=multi-user.target
+
+[Service]
+User=pi
+ExecStart=/home/pi/allsky/allsky.sh
+StandardOutput=null
+StandardError=syslog
+SyslogFacility=local5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This a proposal unit file due to start the allsky.sh at startup as "pi" user.
This unit file is compatible to systemD: this file has to be put in /lib/systemd/system/allsky.service with ownership root:root and permissions: 0644
To enable the service launch (as root):
systemctl daemon-reload
systemctl enable allsky.service
systemctl start allsky.service

The script accept also status and stop:
systemctl status allsky.service
systemctl stop allsky.service

Tested on Raspbian GNU/Linux 9.4 (stretch) on Raspberry Pi3 Model B.