### PR TITLE
Fix startrails generation when read error and no dark enough images

### DIFF
--- a/startrails.cpp
+++ b/startrails.cpp
@@ -59,6 +59,7 @@ int main(int argc, char *argv[])
         if (!image.data)
         {
             std::cout << "Error reading file " << basename(files.gl_pathv[f]) << std::endl;
+            stats.col(f) = 1.0; // mark as invalid
             continue;
         }
 


### PR DESCRIPTION
The statistics vector seems to be zero initialized and if there was an error reading an image I didn't set any value a mean before so in case no frames were darker than threshold, one of these frames was picked as minimum value. The fix is to mark mean value as 1.0 so they don't get picked as minimum frames. 