### PR TITLE
Added check in allsky.sh to ensure a ZWO device is present

### DIFF
--- a/allsky.sh
+++ b/allsky.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+if [ $(lsusb | grep 03c3: -c) -eq 0 ]; then
+        echo ZWO Camera not found.  Exiting. >&2
+        sudo systemctl stop allsky
+        exit 0
+fi
+
 source /home/pi/allsky/config.sh
 source /home/pi/allsky/scripts/filename.sh
 

--- a/allsky.sh
+++ b/allsky.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-if [ $(lsusb | grep 03c3: -c) -eq 0 ]; then
+isPresent=$(lsusb -D $(lsusb | awk '/ 03c3:/ { bus=$2; dev=$4; gsub(/[^0-9]/,"",dev); print "/dev/bus/usb/"bus"/"dev;}') | grep -c 'iProduct .*ASI[0-9]')
+if [ $isPresent -eq 0 ]; then
         echo ZWO Camera not found.  Exiting. >&2
         sudo systemctl stop allsky
         exit 0


### PR DESCRIPTION
* Added check to allsky.sh to ensure a ZWO device is plugged in prior to attempting to start capture.
* If it is not present, stop the systemd allsky unit and exit gracefully with a friendly message.