### PR TITLE
allow for an outline font. might improve text readability

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -49,15 +49,15 @@ void cvText(cv::Mat &img, const char *text, int x, int y, double fontsize, int l
     if (imgtype == ASI_IMG_RAW16)
     {
         if (outlinefont)
-            cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(0,0,0), linewidth+6, linetype);
+            cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(0,0,0), linewidth+4, linetype);
         cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(fontcolor[0], fontcolor[1], fontcolor[2]),
                     linewidth, linetype);
     }
     else
     {
         if (outlinefont)
-            cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(0,0,0, 255), linewidth+6, linetype);
-	cv::putText(img, text, cvPoint(x, y), fontname, fontsize,
+            cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(0,0,0, 255), linewidth+4, linetype);
+        cv::putText(img, text, cvPoint(x, y), fontname, fontsize,
                     cvScalar(fontcolor[0], fontcolor[1], fontcolor[2], 255), linewidth, linetype);
     }
 }

--- a/capture.cpp
+++ b/capture.cpp
@@ -44,16 +44,20 @@ pthread_cond_t cond_SatrtSave;
 //-------------------------------------------------------------------------------------------------------
 
 void cvText(cv::Mat &img, const char *text, int x, int y, double fontsize, int linewidth, int linetype, int fontname,
-            int fontcolor[], int imgtype)
+            int fontcolor[], int imgtype, int outlinefont)
 {
     if (imgtype == ASI_IMG_RAW16)
     {
+        if (outlinefont)
+            cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(0,0,0), linewidth+6, linetype);
         cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(fontcolor[0], fontcolor[1], fontcolor[2]),
                     linewidth, linetype);
     }
     else
     {
-        cv::putText(img, text, cvPoint(x, y), fontname, fontsize,
+        if (outlinefont)
+            cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(0,0,0, 255), linewidth+6, linetype);
+	cv::putText(img, text, cvPoint(x, y), fontname, fontsize,
                     cvScalar(fontcolor[0], fontcolor[1], fontcolor[2], 255), linewidth, linetype);
     }
 }
@@ -170,6 +174,7 @@ int main(int argc, char *argv[])
     char const *ImgText   = "";
     double fontsize       = 0.6;
     int linewidth         = 1;
+    int outlinefont       = 0;
     int fontcolor[3]      = { 255, 0, 0 };
     int smallFontcolor[3] = { 0, 0, 255 };
     int linetype[3]       = { CV_AA, 8, 4 };
@@ -380,6 +385,13 @@ int main(int argc, char *argv[])
             else if (strcmp(argv[i], "-fontline") == 0)
             {
                 linewidth = atoi(argv[i + 1]);
+                i++;
+            }
+            else if (strcmp(argv[i], "-outlinefont") == 0)
+            {
+                outlinefont = atoi(argv[i + 1]);
+				if (outlinefont != 0)
+				    outlinefont = 1;
                 i++;
             }
             else if (strcmp(argv[i], "-flip") == 0)
@@ -653,6 +665,7 @@ int main(int argc, char *argv[])
     printf(" Font Line Type: %d\n", linetype[linenumber]);
     printf(" Font Size: %1.1f\n", fontsize);
     printf(" Font Line: %d\n", linewidth);
+    printf(" Outline Font : %d\n", outlinefont);
     printf(" Flip Image: %d\n", asiFlip);
     printf(" Filename: %s\n", fileName);
     printf(" Latitude: %s\n", latitude);
@@ -780,7 +793,7 @@ int main(int argc, char *argv[])
                         if (time == 1)
                         {
                             cvText(pRgb, bufTime, iTextX, iTextY + (iYOffset / bin), fontsize, linewidth,
-                                   linetype[linenumber], fontname[fontnumber], fontcolor, Image_type);
+                                   linetype[linenumber], fontname[fontnumber], fontcolor, Image_type, outlinefont);
                             iYOffset += 30;
                         }
 
@@ -788,15 +801,15 @@ int main(int argc, char *argv[])
                         {
                             sprintf(bufTemp, "Sensor %.1fC", (float)ltemp / 10);
                             cvText(pRgb, bufTemp, iTextX, iTextY + (iYOffset / bin), fontsize * 0.8, linewidth,
-                                   linetype[linenumber], fontname[fontnumber], smallFontcolor, Image_type);
+                                   linetype[linenumber], fontname[fontnumber], smallFontcolor, Image_type, outlinefont);
                             iYOffset += 30;
                             sprintf(bufTemp, "Exposure %.3f s", (float)autoExp / 1000000);
                             cvText(pRgb, bufTemp, iTextX, iTextY + (iYOffset / bin), fontsize * 0.8, linewidth,
-                                   linetype[linenumber], fontname[fontnumber], smallFontcolor, Image_type);
+                                   linetype[linenumber], fontname[fontnumber], smallFontcolor, Image_type, outlinefont);
                             iYOffset += 30;
                             sprintf(bufTemp, "Gain %d", (int)autoGain);
                             cvText(pRgb, bufTemp, iTextX, iTextY + (iYOffset / bin), fontsize * 0.8, linewidth,
-                                   linetype[linenumber], fontname[fontnumber], smallFontcolor, Image_type);
+                                   linetype[linenumber], fontname[fontnumber], smallFontcolor, Image_type, outlinefont);
                             iYOffset += 30;
                         }
                     }

--- a/settings.json.repo
+++ b/settings.json.repo
@@ -28,6 +28,7 @@
    "fonttype":"0",
    "fontsize":"0.7",
    "fontline":"1",
+   "outlinefont":"0",
    "latitude":"60.7N",
    "longitude":"135.05W",
    "angle":"-6",


### PR DESCRIPTION
Depending on your camera, color scheme, mono/rgb capture, lighting conditions, etc... you might have a hard time reading the overlay text.

This diff adds an option - `outlinefont` - to simply add a thin black border around the text to improve its contrast. If this diff is accepted, I'll do up a corresponding change for the web UI.

Here's what that looks like on a white frame:

![blank_image](https://user-images.githubusercontent.com/1131751/66262961-4e3dcc80-e79f-11e9-8d79-afd634e138de.jpg)

And here's what that looks like on an actual capture:

![real_image](https://user-images.githubusercontent.com/1131751/66262965-82b18880-e79f-11e9-9168-d061ca5408d8.jpg)

Or in the evening:
![evening](https://user-images.githubusercontent.com/1131751/66263513-d2e11880-e7a8-11e9-933f-1a0649902f9a.jpg)
