### PR TITLE
Fix early exit in case no files are found

### DIFF
--- a/keogram.cpp
+++ b/keogram.cpp
@@ -98,6 +98,12 @@ int main(int argc, char *argv[])
     glob_t files;
     std::string wildcard = directory + "/*." + extension;
     glob(wildcard.c_str(), 0, NULL, &files);
+    if (files.gl_pathc == 0)
+    {
+        globfree(&files);
+        std::cout << "No images found, exiting." << std::endl;
+        return 0;
+    }
 
     cv::Mat accumulated;
 

--- a/startrails.cpp
+++ b/startrails.cpp
@@ -46,6 +46,12 @@ int main(int argc, char *argv[])
     glob_t files;
     std::string wildcard = directory + "/*." + extension;
     glob(wildcard.c_str(), 0, NULL, &files);
+    if (files.gl_pathc == 0)
+    {
+        globfree(&files);
+        std::cout << "No images found, exiting." << std::endl;
+        return 0;
+    }
 
     cv::Mat accumulated;
 
@@ -103,13 +109,6 @@ int main(int argc, char *argv[])
         }
     }
 
-    globfree(&files);
-    if (stats.empty())
-    {
-        std::cout << "No images found, exiting." << std::endl;
-	    return 0;
-    }
-
     // Calculate some statistics
     double min_mean, max_mean;
     cv::Point min_loc;
@@ -131,6 +130,7 @@ int main(int argc, char *argv[])
         std::cout << "No images below threshold, writing the minimum image only" << std::endl;
         accumulated = cv::imread(files.gl_pathv[min_loc.x], cv::IMREAD_UNCHANGED);
     }
+    globfree(&files);
 
     std::vector<int> compression_params;
     compression_params.push_back(CV_IMWRITE_PNG_COMPRESSION);


### PR DESCRIPTION
As per comment for startrails.cpp, the fix there caused a possible use-after-free situation and could be done even earlier. Also added similar check to keogram.cpp so we don't produce empty image in case there are no source files.