### PR TITLE
silence format string warning

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -876,9 +876,7 @@ int main(int argc, char *argv[])
                     }
 
                     // Save the image
-                    printf("Saving...");
-                    printf(bufTime);
-                    printf("\n");
+                    printf("%s", bufTime);
                     if (!bSavingImg)
                     {
                         pthread_mutex_lock(&mtx_SaveImg);


### PR DESCRIPTION
capture.cpp:882:28: warning: format not a string literal and no format arguments [-Wformat-security]

found while I was setting up to build and run on x86_64