### PR TITLE
Remove hard coded paths

### DIFF
--- a/allsky.sh
+++ b/allsky.sh
@@ -6,11 +6,11 @@ if [ $isPresent -eq 0 ]; then
         exit 0
 fi
 
-source /home/pi/allsky/config.sh
-source /home/pi/allsky/scripts/filename.sh
+source ${HOME}/allsky/config.sh
+source ${HOME}/allsky/scripts/filename.sh
 
 echo "Starting allsky camera..."
-cd /home/pi/allsky
+cd ${HOME}/allsky
 
 # Building the arguments to pass to the capture binary
 ARGUMENTS=""

--- a/allsky.sh
+++ b/allsky.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+ALLSKY_DIR=$(dirname $BASH_ARGV0)
+cd ${ALLSKY_DIR}
+
 isPresent=$(lsusb -D $(lsusb | awk '/ 03c3:/ { bus=$2; dev=$4; gsub(/[^0-9]/,"",dev); print "/dev/bus/usb/"bus"/"dev;}') | grep -c 'iProduct .*ASI[0-9]')
 if [ $isPresent -eq 0 ]; then
         echo ZWO Camera not found.  Exiting. >&2
@@ -6,11 +10,10 @@ if [ $isPresent -eq 0 ]; then
         exit 0
 fi
 
-source ${HOME}/allsky/config.sh
-source ${HOME}/allsky/scripts/filename.sh
+source ${ALLSKY_DIR}/config.sh
+source ${ALLSKY_DIR}/scripts/filename.sh
 
 echo "Starting allsky camera..."
-cd ${HOME}/allsky
 
 # Building the arguments to pass to the capture binary
 ARGUMENTS=""
@@ -27,6 +30,7 @@ if [[ $1 == "preview" ]] ; then
 fi
 ARGUMENTS="$ARGUMENTS -daytime $DAYTIME"
 
-echo "$ARGUMENTS">>log.txt
+date >> log.txt
+echo "capture $ARGUMENTS" >> log.txt
 
 ./capture $ARGUMENTS

--- a/config.sh.repo
+++ b/config.sh.repo
@@ -1,5 +1,6 @@
 #!/bin/bash
-source ${HOME}/allsky/scripts/ftp-settings.sh
+ALLSKY_DIR=$(dirname $BASH_ARGV0)
+source ${ALLSKY_DIR}/scripts/ftp-settings.sh
 
 # Set to true to upload current image to your website
 UPLOAD_IMG=false
@@ -44,4 +45,4 @@ DARK_FRAME="dark.png"
 DAYTIME="1"
 
 # Path to the camera settings (exposure, gain, delay, overlay, etc)
-CAMERA_SETTINGS="${HOME}/allsky/settings.json"
+CAMERA_SETTINGS="${ALLSKY_DIR}/settings.json"

--- a/config.sh.repo
+++ b/config.sh.repo
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /home/pi/allsky/scripts/ftp-settings.sh
+source ${HOME}/allsky/scripts/ftp-settings.sh
 
 # Set to true to upload current image to your website
 UPLOAD_IMG=false
@@ -44,4 +44,4 @@ DARK_FRAME="dark.png"
 DAYTIME="1"
 
 # Path to the camera settings (exposure, gain, delay, overlay, etc)
-CAMERA_SETTINGS="/home/pi/allsky/settings.json"
+CAMERA_SETTINGS="${HOME}/allsky/settings.json"

--- a/gui/install.sh
+++ b/gui/install.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+SCRIPT_DIR=$(dirname $(realpath $BASH_ARGV0))
+ALLSKY_DIR=$(dirname $SCRIPT_DIR)
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
@@ -18,20 +21,20 @@ lighty-enable-mod fastcgi-php
 service lighttpd restart
 echo -en '\n'
 echo -e "${GREEN}* Configuring lighttpd${NC}"
-cp ${HOME}/allsky/gui/lighttpd.conf /etc/lighttpd/lighttpd.conf
+cp ${ALLSKY_DIR}/gui/lighttpd.conf /etc/lighttpd/lighttpd.conf
 echo -en '\n'
 echo -e "${GREEN}* Changing hostname to allsky${NC}"
 echo "allsky" > /etc/hostname
 sed -i 's/raspberrypi/allsky/g' /etc/hosts
 echo -en '\n'
 echo -e "${GREEN}* Setting avahi-daemon configuration${NC}"
-cp ${HOME}/allsky/gui/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
+cp ${ALLSKY_DIR}/gui/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 echo -en '\n'
 echo -e "${GREEN}* Adding the right permissions to the web server${NC}"
 sed -i '/allsky/d' /etc/sudoers
 sed -i '/www-data/d' /etc/sudoers
 rm -f /etc/sudoers.d/allsky
-cat ${HOME}/allsky/gui/sudoers >> /etc/sudoers.d/allsky
+cat ${ALLSKY_DIR}/gui/sudoers >> /etc/sudoers.d/allsky
 echo -en '\n'
 echo -e "${GREEN}* Retrieving github files to build admin portal${NC}"
 rm -rf /var/www/html
@@ -40,12 +43,12 @@ chown -R www-data:www-data /var/www/html
 mkdir /etc/raspap
 mv /var/www/html/raspap.php /etc/raspap/
 mv /var/www/html/camera_options.json /etc/raspap/
-cp ${HOME}/allsky/settings.json /etc/raspap/settings.json
+cp ${ALLSKY_DIR}/settings.json /etc/raspap/settings.json
 chown -R www-data:www-data /etc/raspap
 usermod -a -G www-data pi
 echo -en '\n'
 echo -e "${GREEN}* Modify config.sh${NC}"
-sed -i '/CAMERA_SETTINGS=/c\CAMERA_SETTINGS="/etc/raspap/settings.json"' ${HOME}/allsky/config.sh
+sed -i '/CAMERA_SETTINGS=/c\CAMERA_SETTINGS="/etc/raspap/settings.json"' ${ALLSKY_DIR}/config.sh
 echo -en '\n'
 echo -en '\n'
 echo "The Allsky Portal is now installed"

--- a/gui/install.sh
+++ b/gui/install.sh
@@ -18,20 +18,20 @@ lighty-enable-mod fastcgi-php
 service lighttpd restart
 echo -en '\n'
 echo -e "${GREEN}* Configuring lighttpd${NC}"
-cp /home/pi/allsky/gui/lighttpd.conf /etc/lighttpd/lighttpd.conf
+cp ${HOME}/allsky/gui/lighttpd.conf /etc/lighttpd/lighttpd.conf
 echo -en '\n'
 echo -e "${GREEN}* Changing hostname to allsky${NC}"
 echo "allsky" > /etc/hostname
 sed -i 's/raspberrypi/allsky/g' /etc/hosts
 echo -en '\n'
 echo -e "${GREEN}* Setting avahi-daemon configuration${NC}"
-cp /home/pi/allsky/gui/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
+cp ${HOME}/allsky/gui/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 echo -en '\n'
 echo -e "${GREEN}* Adding the right permissions to the web server${NC}"
 sed -i '/allsky/d' /etc/sudoers
 sed -i '/www-data/d' /etc/sudoers
 rm -f /etc/sudoers.d/allsky
-cat /home/pi/allsky/gui/sudoers >> /etc/sudoers.d/allsky
+cat ${HOME}/allsky/gui/sudoers >> /etc/sudoers.d/allsky
 echo -en '\n'
 echo -e "${GREEN}* Retrieving github files to build admin portal${NC}"
 rm -rf /var/www/html
@@ -40,12 +40,12 @@ chown -R www-data:www-data /var/www/html
 mkdir /etc/raspap
 mv /var/www/html/raspap.php /etc/raspap/
 mv /var/www/html/camera_options.json /etc/raspap/
-cp /home/pi/allsky/settings.json /etc/raspap/settings.json
+cp ${HOME}/allsky/settings.json /etc/raspap/settings.json
 chown -R www-data:www-data /etc/raspap
 usermod -a -G www-data pi
 echo -en '\n'
 echo -e "${GREEN}* Modify config.sh${NC}"
-sed -i '/CAMERA_SETTINGS=/c\CAMERA_SETTINGS="/etc/raspap/settings.json"' /home/pi/allsky/config.sh
+sed -i '/CAMERA_SETTINGS=/c\CAMERA_SETTINGS="/etc/raspap/settings.json"' ${HOME}/allsky/config.sh
 echo -en '\n'
 echo -en '\n'
 echo "The Allsky Portal is now installed"

--- a/scripts/allsky_mfs.sh
+++ b/scripts/allsky_mfs.sh
@@ -13,20 +13,13 @@
 # having to remount the overlayfs
 # 
 # This assumes that an entire storage device will be used exclusively for
-# image storage by allsky.
-
-#CONFIGURED=yes
-
-if [ "x$CONFIGURED" != "xyes" ] ; then
-	echo "Please edit this script to configure it for your system."
-	echo "Once this is done, uncomment 'CONFIGURED=yes'"
-	exit 1
-fi
+# image storage by allsky, eg. a usb stick like /dev/sda1
 
 # The actual allsky source tree
 ALLSKY=${ALLSKY:-/home/allsky-src}
 
-# The running directory, will be overlaid by a tmpfs to grab the writes
+# The running code directory, where allsky thinks it's running. This will be
+# overlaid by a tmpfs to grab any temporary scribbling (ie. current frame).
 ALLSKY_RUN=${ALLSKY_RUN:-/home/allsky}
 
 # set these to the user running allsky. Pi, dietpi, root, yourself - doesn't
@@ -46,6 +39,16 @@ TMPSIZE=8m
 
 # stick this in /run (another tmpfs) since it's transient
 TMPFS=/run/overlayfs/allsky
+
+#CONFIGURED=yes
+
+if [ "x$CONFIGURED" != "xyes" ] ; then
+	echo "Please edit this script to configure it for your system."
+	echo "Once this is done, uncomment 'CONFIGURED=yes'"
+	exit 1
+fi
+
+# No changes should be required below this line
 
 # make the tempfs for storing the current captures
 mkdir -p ${TMPFS}

--- a/scripts/endOfNight.sh
+++ b/scripts/endOfNight.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-source /home/pi/allsky/config.sh
-source /home/pi/allsky/scripts/filename.sh
+source ${HOME}/allsky/config.sh
+source ${HOME}/allsky/scripts/filename.sh
 
-cd  /home/pi/allsky/scripts
+cd  ${HOME}/allsky/scripts
 LAST_NIGHT=$(date -d '12 hours ago' +'%Y%m%d')
 
 # Post end of night data. This includes next twilight time
@@ -21,10 +21,10 @@ fi
 # Generate keogram from collected images
 if [[ $KEOGRAM == "true" ]]; then
         echo -e "Generating Keogram\n"
-	mkdir -p /home/pi/allsky/images/$LAST_NIGHT/keogram/
-        ../keogram /home/pi/allsky/images/$LAST_NIGHT/ $EXTENSION /home/pi/allsky/images/$LAST_NIGHT/keogram/keogram-$LAST_NIGHT.jpg
+	mkdir -p ${HOME}/allsky/images/$LAST_NIGHT/keogram/
+        ../keogram ${HOME}/allsky/images/$LAST_NIGHT/ $EXTENSION ${HOME}/allsky/images/$LAST_NIGHT/keogram/keogram-$LAST_NIGHT.jpg
 	if [[ $UPLOAD_KEOGRAM == "true" ]] ; then
-		OUTPUT="/home/pi/allsky/images/$LAST_NIGHT/keogram/keogram-$LAST_NIGHT.jpg"
+		OUTPUT="${HOME}/allsky/images/$LAST_NIGHT/keogram/keogram-$LAST_NIGHT.jpg"
                 lftp "$PROTOCOL"://"$USER":"$PASSWORD"@"$HOST":"$KEOGRAM_DIR" \
                         -e "set net:max-retries 1; put $OUTPUT; bye"
 	fi
@@ -34,10 +34,10 @@ fi
 # Generate startrails from collected images. Treshold set to 0.1 by default in config.sh to avoid stacking over-exposed images
 if [[ $STARTRAILS == "true" ]]; then
         echo -e "Generating Startrails\n"
-	mkdir -p /home/pi/allsky/images/$LAST_NIGHT/startrails/
-        ../startrails /home/pi/allsky/images/$LAST_NIGHT/ $EXTENSION $BRIGHTNESS_THRESHOLD /home/pi/allsky/images/$LAST_NIGHT/startrails/startrails-$LAST_NIGHT.jpg
+	mkdir -p ${HOME}/allsky/images/$LAST_NIGHT/startrails/
+        ../startrails ${HOME}/allsky/images/$LAST_NIGHT/ $EXTENSION $BRIGHTNESS_THRESHOLD ${HOME}/allsky/images/$LAST_NIGHT/startrails/startrails-$LAST_NIGHT.jpg
 	if [[ $UPLOAD_STARTRAILS == "true" ]] ; then
-		OUTPUT="/home/pi/allsky/images/$LAST_NIGHT/startrails/startrails-$LAST_NIGHT.jpg"
+		OUTPUT="${HOME}/allsky/images/$LAST_NIGHT/startrails/startrails-$LAST_NIGHT.jpg"
                 lftp "$PROTOCOL"://"$USER":"$PASSWORD"@"$HOST":"$STARTRAILS_DIR" \
 			-e "set net:max-retries 1; put $OUTPUT; bye"
         fi
@@ -55,7 +55,7 @@ fi
 # Automatically delete old images and videos
 if [[ $AUTO_DELETE == "true" ]]; then
 	del=$(date --date="$NIGHTS_TO_KEEP days ago" +%Y%m%d)
-	for i in `find /home/pi/allsky/images/ -type d -name "2*"`; do
+	for i in `find ${HOME}/allsky/images/ -type d -name "2*"`; do
 	  (($del > $(basename $i))) && rm -rf $i
 	done
 fi

--- a/scripts/endOfNight.sh
+++ b/scripts/endOfNight.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
-source ${HOME}/allsky/config.sh
-source ${HOME}/allsky/scripts/filename.sh
 
-cd  ${HOME}/allsky/scripts
+SCRIPT_DIR=$(dirname $(realpath $BASH_ARGV0))
+ALLSKY_DIR=$(dirname $SCRIPT_DIR)
+source ${ALLSKY_DIR}/config.sh
+source ${ALLSKY_DIR}/scripts/filename.sh
+cd ${ALLSKY_DIR}/scripts
+
 LAST_NIGHT=$(date -d '12 hours ago' +'%Y%m%d')
 
 # Post end of night data. This includes next twilight time
 if [[ $POST_END_OF_NIGHT_DATA == "true" ]]; then
-        echo -e "Posting next twilight time to let server know when to resume liveview\n"
-        ./postData.sh
+    echo -e "Posting next twilight time to let server know when to resume liveview\n"
+    ./postData.sh
 	echo -e "\n"
 fi
 
@@ -16,15 +19,15 @@ fi
 # keograms and startrails. This can take several (tens of) minutes to run
 # and isn't necessary unless your system produces corrupt images which then
 # generate funny colors in the summary images...
-# ./removeBadImages.sh /home/pi/allsky/images/$LAST_NIGHT/  
+# ./removeBadImages.sh ${ALLSKY_DIR}/images/$LAST_NIGHT/
 
 # Generate keogram from collected images
 if [[ $KEOGRAM == "true" ]]; then
-        echo -e "Generating Keogram\n"
-	mkdir -p ${HOME}/allsky/images/$LAST_NIGHT/keogram/
-        ../keogram ${HOME}/allsky/images/$LAST_NIGHT/ $EXTENSION ${HOME}/allsky/images/$LAST_NIGHT/keogram/keogram-$LAST_NIGHT.jpg
+    echo -e "Generating Keogram\n"
+	mkdir -p ${ALLSKY_DIR}/images/$LAST_NIGHT/keogram/
+    ${ALLSKY_DIR}/keogram ${ALLSKY_DIR}/images/$LAST_NIGHT/ $EXTENSION ${ALLSKY_DIR}/images/$LAST_NIGHT/keogram/keogram-$LAST_NIGHT.jpg
 	if [[ $UPLOAD_KEOGRAM == "true" ]] ; then
-		OUTPUT="${HOME}/allsky/images/$LAST_NIGHT/keogram/keogram-$LAST_NIGHT.jpg"
+		OUTPUT="${ALLSKY_DIR}/images/$LAST_NIGHT/keogram/keogram-$LAST_NIGHT.jpg"
                 lftp "$PROTOCOL"://"$USER":"$PASSWORD"@"$HOST":"$KEOGRAM_DIR" \
                         -e "set net:max-retries 1; put $OUTPUT; bye"
 	fi
@@ -33,11 +36,11 @@ fi
 
 # Generate startrails from collected images. Treshold set to 0.1 by default in config.sh to avoid stacking over-exposed images
 if [[ $STARTRAILS == "true" ]]; then
-        echo -e "Generating Startrails\n"
-	mkdir -p ${HOME}/allsky/images/$LAST_NIGHT/startrails/
-        ../startrails ${HOME}/allsky/images/$LAST_NIGHT/ $EXTENSION $BRIGHTNESS_THRESHOLD ${HOME}/allsky/images/$LAST_NIGHT/startrails/startrails-$LAST_NIGHT.jpg
+    echo -e "Generating Startrails\n"
+	mkdir -p ${ALLSKY_DIR}/images/$LAST_NIGHT/startrails/
+    ${ALLSKY_DIR}/startrails ${ALLSKY_DIR}/images/$LAST_NIGHT/ $EXTENSION $BRIGHTNESS_THRESHOLD ${ALLSKY_DIR}/images/$LAST_NIGHT/startrails/startrails-$LAST_NIGHT.jpg
 	if [[ $UPLOAD_STARTRAILS == "true" ]] ; then
-		OUTPUT="${HOME}/allsky/images/$LAST_NIGHT/startrails/startrails-$LAST_NIGHT.jpg"
+		OUTPUT="${ALLSKY_DIR}/images/$LAST_NIGHT/startrails/startrails-$LAST_NIGHT.jpg"
                 lftp "$PROTOCOL"://"$USER":"$PASSWORD"@"$HOST":"$STARTRAILS_DIR" \
 			-e "set net:max-retries 1; put $OUTPUT; bye"
         fi
@@ -55,7 +58,7 @@ fi
 # Automatically delete old images and videos
 if [[ $AUTO_DELETE == "true" ]]; then
 	del=$(date --date="$NIGHTS_TO_KEEP days ago" +%Y%m%d)
-	for i in `find ${HOME}/allsky/images/ -type d -name "2*"`; do
+	for i in `find ${ALLSKY_DIR}/images/ -type d -name "2*"`; do
 	  (($del > $(basename $i))) && rm -rf $i
 	done
 fi

--- a/scripts/ftp-settings.sh.repo
+++ b/scripts/ftp-settings.sh.repo
@@ -1,4 +1,10 @@
 #!/bin/bash
+SCRIPT_DIR=$(dirname $(realpath $BASH_ARGV0))
+ALLSKY_DIR=$(dirname $SCRIPT_DIR)
+source ${ALLSKY_DIR}/config.sh
+source ${ALLSKY_DIR}/scripts/filename.sh
+cd ${ALLSKY_DIR}
+
 
 # FTP/SFTP settings
 PROTOCOL='ftp'

--- a/scripts/generateForDay.sh
+++ b/scripts/generateForDay.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-source /home/pi/allsky/config.sh
-source /home/pi/allsky/scripts/filename.sh
+source ${HOME}/allsky/config.sh
+source ${HOME}/allsky/scripts/filename.sh
 
-cd  /home/pi/allsky/scripts
+cd  ${HOME}/allsky/scripts
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -17,14 +17,14 @@ fi
 
 # Generate timelapse from collected images
 echo -e "Generating Keogram\n"
-mkdir -p /home/pi/allsky/images/$1/keogram/
-../keogram /home/pi/allsky/images/$1/ $EXTENSION /home/pi/allsky/images/$1/keogram/keogram-$1.jpg
+mkdir -p ${HOME}/allsky/images/$1/keogram/
+../keogram ${HOME}/allsky/images/$1/ $EXTENSION ${HOME}/allsky/images/$1/keogram/keogram-$1.jpg
 echo -e "\n"
 
 # Generate startrails from collected images. Treshold set to 0.1 by default in config.sh to avoid stacking over-exposed images
 echo -e "Generating Startrails\n"
-mkdir -p /home/pi/allsky/images/$1/startrails/
-../startrails /home/pi/allsky/images/$1/ $EXTENSION $BRIGHTNESS_THRESHOLD /home/pi/allsky/images/$1/startrails/startrails-$1.jpg
+mkdir -p ${HOME}/allsky/images/$1/startrails/
+../startrails ${HOME}/allsky/images/$1/ $EXTENSION $BRIGHTNESS_THRESHOLD ${HOME}/allsky/images/$1/startrails/startrails-$1.jpg
 echo -e "\n"
 
 # Generate timelapse from collected images

--- a/scripts/generateForDay.sh
+++ b/scripts/generateForDay.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-source ${HOME}/allsky/config.sh
-source ${HOME}/allsky/scripts/filename.sh
-
-cd  ${HOME}/allsky/scripts
+SCRIPT_DIR=$(dirname $(realpath $BASH_ARGV0))
+ALLSKY_DIR=$(dirname $SCRIPT_DIR)
+source ${ALLSKY_DIR}/config.sh
+source ${ALLSKY_DIR}/scripts/filename.sh
+cd ${ALLSKY_DIR}/scripts
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -17,14 +18,14 @@ fi
 
 # Generate timelapse from collected images
 echo -e "Generating Keogram\n"
-mkdir -p ${HOME}/allsky/images/$1/keogram/
-../keogram ${HOME}/allsky/images/$1/ $EXTENSION ${HOME}/allsky/images/$1/keogram/keogram-$1.jpg
+mkdir -p ${ALLSKY_DIR}/images/$1/keogram/
+../keogram ${ALLSKY_DIR}/images/$1/ $EXTENSION ${ALLSKY_DIR}/images/$1/keogram/keogram-$1.jpg
 echo -e "\n"
 
 # Generate startrails from collected images. Treshold set to 0.1 by default in config.sh to avoid stacking over-exposed images
 echo -e "Generating Startrails\n"
-mkdir -p ${HOME}/allsky/images/$1/startrails/
-../startrails ${HOME}/allsky/images/$1/ $EXTENSION $BRIGHTNESS_THRESHOLD ${HOME}/allsky/images/$1/startrails/startrails-$1.jpg
+mkdir -p ${ALLSKY_DIR}/images/$1/startrails/
+../startrails ${ALLSKY_DIR}/images/$1/ $EXTENSION $BRIGHTNESS_THRESHOLD ${ALLSKY_DIR}/images/$1/startrails/startrails-$1.jpg
 echo -e "\n"
 
 # Generate timelapse from collected images

--- a/scripts/postData.sh
+++ b/scripts/postData.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
-source ${HOME}/allsky/config.sh
+SCRIPT_DIR=$(dirname $(realpath $BASH_ARGV0))
+ALLSKY_DIR=$(dirname $SCRIPT_DIR)
+source ${ALLSKY_DIR}/config.sh
+source ${ALLSKY_DIR}/scripts/filename.sh
+cd ${ALLSKY_DIR}/scripts
+
 
 # TODO Needs fixing when civil twilight happens after midnight
-cd ${HOME}/allsky/scripts
-
+# TODO get this from settings.json...
 latitude=60.7N
 longitude=135.02W
 timezone=-0700

--- a/scripts/postData.sh
+++ b/scripts/postData.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-source /home/pi/allsky/config.sh
+source ${HOME}/allsky/config.sh
 
 # TODO Needs fixing when civil twilight happens after midnight
-cd /home/pi/allsky/scripts
+cd ${HOME}/allsky/scripts
 
 latitude=60.7N
 longitude=135.02W

--- a/scripts/saveImageDay.sh
+++ b/scripts/saveImageDay.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-source /home/pi/allsky/config.sh
-source /home/pi/allsky/scripts/filename.sh
+source ${HOME}/allsky/config.sh
+source ${HOME}/allsky/scripts/filename.sh
 
-cd /home/pi/allsky
+cd ${HOME}/allsky
 
 IMAGE_TO_USE="$FULL_FILENAME"
 cp $IMAGE_TO_USE "liveview-$FILENAME.$EXTENSION"

--- a/scripts/saveImageDay.sh
+++ b/scripts/saveImageDay.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-source ${HOME}/allsky/config.sh
-source ${HOME}/allsky/scripts/filename.sh
 
-cd ${HOME}/allsky
+SCRIPT_DIR=$(dirname $(realpath $BASH_ARGV0))
+ALLSKY_DIR=$(dirname $SCRIPT_DIR)
+source ${ALLSKY_DIR}/config.sh
+source ${ALLSKY_DIR}/scripts/filename.sh
+cd ${ALLSKY_DIR}
 
 IMAGE_TO_USE="$FULL_FILENAME"
 cp $IMAGE_TO_USE "liveview-$FILENAME.$EXTENSION"

--- a/scripts/saveImageNight.sh
+++ b/scripts/saveImageNight.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-source ${HOME}/allsky/config.sh
-source ${HOME}/allsky/scripts/filename.sh
-
-cd ${HOME}/allsky
+SCRIPT_DIR=$(dirname $(realpath $BASH_ARGV0))
+ALLSKY_DIR=$(dirname $SCRIPT_DIR)
+source ${ALLSKY_DIR}/config.sh
+source ${ALLSKY_DIR}/scripts/filename.sh
+cd ${ALLSKY_DIR}
 
 # Make a directory to store current night images
 # the 12 hours ago option ensures that we're always using today's date even at high latitudes where civil twilight can start after midnight

--- a/scripts/saveImageNight.sh
+++ b/scripts/saveImageNight.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-source /home/pi/allsky/config.sh
-source /home/pi/allsky/scripts/filename.sh
+source ${HOME}/allsky/config.sh
+source ${HOME}/allsky/scripts/filename.sh
 
-cd /home/pi/allsky
+cd ${HOME}/allsky
 
 # Make a directory to store current night images
 # the 12 hours ago option ensures that we're always using today's date even at high latitudes where civil twilight can start after midnight

--- a/scripts/timelapse.sh
+++ b/scripts/timelapse.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-source ${HOME}/allsky/config.sh
-source ${HOME}/allsky/scripts/filename.sh
-
-cd ${HOME}/allsky/
+SCRIPT_DIR=$(dirname $(realpath $BASH_ARGV0))
+ALLSKY_DIR=$(dirname $SCRIPT_DIR)
+source ${ALLSKY_DIR}/config.sh
+source ${ALLSKY_DIR}/scripts/filename.sh
+cd ${ALLSKY_DIR}
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -16,12 +17,14 @@ if [ $# -lt 1 ]
 fi
 
 echo -en "* ${GREEN}Creating symlinks to generate timelapse${NC}\n"
-mkdir ${HOME}/allsky/images/$1/sequence/
+mkdir ${ALLSKY_DIR}/images/$1/sequence/
+
 # find images, make symlinks sequentially and start avconv to build mp4; upload mp4 and move directory
-find "${HOME}/allsky/images/$1" -name "*.$EXTENSION" -size 0 -delete
-ls -rt ${HOME}/allsky/images/$1/*.$EXTENSION |
-gawk 'BEGIN{ a=1 }{ printf "ln -sv %s ${HOME}/allsky/images/'$1'/sequence/%04d.'$EXTENSION'\n", $0, a++ }' |
-bash
+find "${ALLSKY_DIR}/images/$1" -name "*.$EXTENSION" -size 0 -delete
+ls -rt ${ALLSKY_DIR}/images/$1/*.$EXTENSION | \
+	gawk 'BEGIN{ a=1 }{ printf "ln -sv %s ${ALLSKY_DIR}/images/'$1'/sequence/%04d.'$EXTENSION'\n", $0, a++ }' | \
+	bash
+
 ffmpeg -y -f image2 -r $FPS -i images/$1/sequence/%04d.$EXTENSION -vcodec libx264 -b:v 2000k -pix_fmt yuv420p images/$1/allsky-$1.mp4
 
 if [ "$UPLOAD_VIDEO" = true ] ; then
@@ -29,6 +32,6 @@ if [ "$UPLOAD_VIDEO" = true ] ; then
 fi
 
 echo -en "* ${GREEN}Deleting sequence${NC}\n"
-rm -rf ${HOME}/allsky/images/$1/sequence
+rm -rf ${ALLSKY_DIR}/images/$1/sequence
 
 echo -en "* ${GREEN}Timelapse was created${NC}\n"

--- a/scripts/timelapse.sh
+++ b/scripts/timelapse.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-source /home/pi/allsky/config.sh
-source /home/pi/allsky/scripts/filename.sh
+source ${HOME}/allsky/config.sh
+source ${HOME}/allsky/scripts/filename.sh
 
-cd /home/pi/allsky/
+cd ${HOME}/allsky/
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -16,11 +16,11 @@ if [ $# -lt 1 ]
 fi
 
 echo -en "* ${GREEN}Creating symlinks to generate timelapse${NC}\n"
-mkdir /home/pi/allsky/images/$1/sequence/
+mkdir ${HOME}/allsky/images/$1/sequence/
 # find images, make symlinks sequentially and start avconv to build mp4; upload mp4 and move directory
-find "/home/pi/allsky/images/$1" -name "*.$EXTENSION" -size 0 -delete
-ls -rt /home/pi/allsky/images/$1/*.$EXTENSION |
-gawk 'BEGIN{ a=1 }{ printf "ln -sv %s /home/pi/allsky/images/'$1'/sequence/%04d.'$EXTENSION'\n", $0, a++ }' |
+find "${HOME}/allsky/images/$1" -name "*.$EXTENSION" -size 0 -delete
+ls -rt ${HOME}/allsky/images/$1/*.$EXTENSION |
+gawk 'BEGIN{ a=1 }{ printf "ln -sv %s ${HOME}/allsky/images/'$1'/sequence/%04d.'$EXTENSION'\n", $0, a++ }' |
 bash
 ffmpeg -y -f image2 -r $FPS -i images/$1/sequence/%04d.$EXTENSION -vcodec libx264 -b:v 2000k -pix_fmt yuv420p images/$1/allsky-$1.mp4
 
@@ -29,6 +29,6 @@ if [ "$UPLOAD_VIDEO" = true ] ; then
 fi
 
 echo -en "* ${GREEN}Deleting sequence${NC}\n"
-rm -rf /home/pi/allsky/images/$1/sequence
+rm -rf ${HOME}/allsky/images/$1/sequence
 
 echo -en "* ${GREEN}Timelapse was created${NC}\n"

--- a/scripts/uploadForDay.sh
+++ b/scripts/uploadForDay.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-source /home/pi/allsky/config.sh
-source /home/pi/allsky/scripts/filename.sh
+source ${HOME}/allsky/config.sh
+source ${HOME}/allsky/scripts/filename.sh
 
-cd  /home/pi/allsky/scripts
+cd  ${HOME}/allsky/scripts
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -17,18 +17,18 @@ fi
 
 # Upload keogram
 echo -e "Uploading Keogram\n"
-KEOGRAM="/home/pi/allsky/images/$1/keogram/keogram-$1.jpg"
+KEOGRAM="${HOME}/allsky/images/$1/keogram/keogram-$1.jpg"
 lftp "$PROTOCOL"://"$USER":"$PASSWORD"@"$HOST":"$KEOGRAM_DIR" -e "set net:max-retries 1; put $KEOGRAM; bye" -u "$USER","$PASSWORD"
 echo -e "\n"
 
 # Upload Startrails
 echo -e "Uploading Startrails\n"
-STARTRAILS="/home/pi/allsky/images/$1/startrails/startrails-$1.jpg"
+STARTRAILS="${HOME}/allsky/images/$1/startrails/startrails-$1.jpg"
 lftp "$PROTOCOL"://"$USER":"$PASSWORD"@"$HOST":"$STARTRAILS_DIR" -e "set net:max-retries 1; put $STARTRAILS; bye"
 echo -e "\n"
 
 # Upload timelapse
 echo -e "Uploading Timelapse\n"
-TIMELAPSE="/home/pi/allsky/images/$1/allsky-$1.mp4"
+TIMELAPSE="${HOME}/allsky/images/$1/allsky-$1.mp4"
 lftp "$PROTOCOL"://"$USER":"$PASSWORD"@"$HOST":"$MP4DIR" -e "set net:max-retries 1; put $TIMELAPSE; bye"
 echo -e "\n"

--- a/scripts/uploadForDay.sh
+++ b/scripts/uploadForDay.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-source ${HOME}/allsky/config.sh
-source ${HOME}/allsky/scripts/filename.sh
-
-cd  ${HOME}/allsky/scripts
+SCRIPT_DIR=$(dirname $(realpath $BASH_ARGV0))
+ALLSKY_DIR=$(dirname $SCRIPT_DIR)
+source ${ALLSKY_DIR}/config.sh
+source ${ALLSKY_DIR}/scripts/filename.sh
+cd  ${ALLSKY_DIR}/scripts
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -17,18 +18,18 @@ fi
 
 # Upload keogram
 echo -e "Uploading Keogram\n"
-KEOGRAM="${HOME}/allsky/images/$1/keogram/keogram-$1.jpg"
+KEOGRAM="${ALLSKY_DIR}/images/$1/keogram/keogram-$1.jpg"
 lftp "$PROTOCOL"://"$USER":"$PASSWORD"@"$HOST":"$KEOGRAM_DIR" -e "set net:max-retries 1; put $KEOGRAM; bye" -u "$USER","$PASSWORD"
 echo -e "\n"
 
 # Upload Startrails
 echo -e "Uploading Startrails\n"
-STARTRAILS="${HOME}/allsky/images/$1/startrails/startrails-$1.jpg"
+STARTRAILS="${ALLSKY_DIR}/images/$1/startrails/startrails-$1.jpg"
 lftp "$PROTOCOL"://"$USER":"$PASSWORD"@"$HOST":"$STARTRAILS_DIR" -e "set net:max-retries 1; put $STARTRAILS; bye"
 echo -e "\n"
 
 # Upload timelapse
 echo -e "Uploading Timelapse\n"
-TIMELAPSE="${HOME}/allsky/images/$1/allsky-$1.mp4"
+TIMELAPSE="${ALLSKY_DIR}/images/$1/allsky-$1.mp4"
 lftp "$PROTOCOL"://"$USER":"$PASSWORD"@"$HOST":"$MP4DIR" -e "set net:max-retries 1; put $TIMELAPSE; bye"
 echo -e "\n"


### PR DESCRIPTION
This PR causes all the scripts to compute their location and thus the locations of their parent `allsky` directory so they can do the right things. I am running my main sky camera from `/home/allsky`, but am developing on my laptop under `/home/ckuethe/github/allsky-ckuethe` and both of these machines compute their paths properly now.

Fixes #137 