### PR TITLE
Add faststart to ffmpeg command line

### DIFF
--- a/scripts/timelapse.sh
+++ b/scripts/timelapse.sh
@@ -30,6 +30,7 @@ ffmpeg -y -f image2 \
 	-vcodec libx264 \
 	-b:v 2000k \
 	-pix_fmt yuv420p \
+	-movflags +faststart \
 	images/$1/allsky-$1.mp4
 
 if [ "$UPLOAD_VIDEO" = true ] ; then

--- a/scripts/timelapse.sh
+++ b/scripts/timelapse.sh
@@ -17,12 +17,20 @@ fi
 
 echo -en "* ${GREEN}Creating symlinks to generate timelapse${NC}\n"
 mkdir /home/pi/allsky/images/$1/sequence/
+
 # find images, make symlinks sequentially and start avconv to build mp4; upload mp4 and move directory
 find "/home/pi/allsky/images/$1" -name "*.$EXTENSION" -size 0 -delete
 ls -rt /home/pi/allsky/images/$1/*.$EXTENSION |
 gawk 'BEGIN{ a=1 }{ printf "ln -sv %s /home/pi/allsky/images/'$1'/sequence/%04d.'$EXTENSION'\n", $0, a++ }' |
 bash
-ffmpeg -y -f image2 -r $FPS -i images/$1/sequence/%04d.$EXTENSION -vcodec libx264 -b:v 2000k -pix_fmt yuv420p images/$1/allsky-$1.mp4
+
+ffmpeg -y -f image2 \
+	-r $FPS \
+	-i images/$1/sequence/%04d.$EXTENSION \
+	-vcodec libx264 \
+	-b:v 2000k \
+	-pix_fmt yuv420p \
+	images/$1/allsky-$1.mp4
 
 if [ "$UPLOAD_VIDEO" = true ] ; then
 	lftp "$PROTOCOL"://"$USER":"$PASSWORD"@"$HOST":"$MP4DIR" -e "set net:max-retries 1; put images/$1/allsky-$1.mp4; bye"


### PR DESCRIPTION
The `-movflags +faststart` option to `ffmpeg` creates the mp4 file such that the file's movie ("MOOV") atom, the bit of metadata that  describes the movie's data, appears at the beginning of the file instead of the end. This allows playback to begin once sufficient frame data is downloaded instead of until the entire mp4 file is downloaded, as the MOOV atom is usually placed at the end because it contains data that is known only once the entire movie is encoded. 