### PR TITLE
Fix for font colours on RAW16 Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ nano settings.json
 | textx | 15 | Horizontal text placement from the left |
 | texty | 35 | Vertical text placement from the top |
 | fontname | 0 | Font type for the overlay. 0=Simplex, 1=Plain, 2=Duplex, 3=Complex, 4=Triplex, 5=Complex small, 6=Script simplex, 7=Script complex |
-| fontcolor | 255 255 255 | Font color in BGR |
-| smallfontcolor | 0 0 255 | Small Font color in BGR |
+| fontcolor | 255 255 255 | Font color in BGR. NOTE: When using RAW 16 only the B and G values are used i.e. 255 128 0 |
+| smallfontcolor | 0 0 255 | Small Font color in BGR. NOTE: When using RAW 16 only the B and G values are used i.e. 255 128 0 |
 | fontsize | 0.7 | Font size |
 | fonttype | 0 | Controls the smoothness of the fonts. 0=Antialiased, 1=8 Connected, 2=4 Connected. |
 | fontline | 1 | font line thickness |

--- a/capture.cpp
+++ b/capture.cpp
@@ -50,15 +50,21 @@ pthread_cond_t cond_SatrtSave;
 //-------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------
 
+// Create Hex value from RGB
+unsigned long createRGB(int r, int g, int b)
+{
+    return ((r & 0xff) << 16) + ((g & 0xff) << 8) + (b & 0xff);
+}
+
 void cvText(cv::Mat &img, const char *text, int x, int y, double fontsize, int linewidth, int linetype, int fontname,
             int fontcolor[], int imgtype, int outlinefont)
 {
     if (imgtype == ASI_IMG_RAW16)
     {
+		unsigned long fontcolor16 = createRGB(fontcolor[2], fontcolor[1], fontcolor[0]);
         if (outlinefont)
             cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(0,0,0), linewidth+4, linetype);
-        cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(fontcolor[0], fontcolor[1], fontcolor[2]),
-                    linewidth, linetype);
+        cv::putText(img, text, cvPoint(x, y), fontname, fontsize, fontcolor16, linewidth, linetype);
     }
     else
     {


### PR DESCRIPTION
Allows greyscale colours to be used on RAW16 images. The normal colour settings are used but only the B & G values. The R value MUST be 0.

So white would be 255 255 0 and a lighter grey 255 128 0

Also needs a change making to the UI to amend the help text for the camera config?