### PR TITLE
Cropping

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ nano config.sh
 | DAYTIME | 1 | Set to 0 to disable daytime liveview. |
 | CAPTURE_24HR | false | Set to true to save images during both night and day |
 | CAMERA_SETTINGS | /home/pi/allsky/settings.json | Path to the camera settings file. **Note**: If using the GUI, this path will change to /var/www/html/settings.json |
+| CROP_WIDTH | n/a | The width of the resulting image |
+| CROP_HEIGHT | n/a | The height of the resulting image |
+| CROP_OFFSET_X | 0 | The x offset to use when cropping |
+| CROP_OFFSET_Y | 0 | The y offset to use when cropping |
+
+When using the cropping options the image is cropped from the center so you will need to experiment with the correct width and height values. Normally there will be no need to amend the offset values.
 
 In order to upload images and videos to your website, you'll need to fill your FTP connection details in **ftp-settings.sh**
 ```shell

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ nano config.sh
 | DAYTIME | 1 | Set to 0 to disable daytime liveview. |
 | CAPTURE_24HR | false | Set to true to save images during both night and day |
 | CAMERA_SETTINGS | /home/pi/allsky/settings.json | Path to the camera settings file. **Note**: If using the GUI, this path will change to /var/www/html/settings.json |
+| CROP_IMAGE | false | Crop the captured image BEFORE any other processing. This inproves the subsequent images when using a fisheye lens |
 | CROP_WIDTH | n/a | The width of the resulting image |
 | CROP_HEIGHT | n/a | The height of the resulting image |
 | CROP_OFFSET_X | 0 | The x offset to use when cropping |

--- a/config.sh.repo
+++ b/config.sh.repo
@@ -46,5 +46,12 @@ DAYTIME="1"
 # Set 24Hr capture to true to save both night and day images to disk. By default, only night images are saved.
 CAPTURE_24HR=false
 
+# Crop the captured image, used to improve the images when using a fisheye lens
+CROP_IMAGE=false
+CROP_WIDTH=640
+CROP_HEIGHT=480
+CROP_OFFSET_X=0
+CROP_OFFSET_Y=0
+
 # Path to the camera settings (exposure, gain, delay, overlay, etc)
 CAMERA_SETTINGS="$ALLSKY_HOME/settings.json"

--- a/scripts/saveImageDay.sh
+++ b/scripts/saveImageDay.sh
@@ -13,6 +13,12 @@ if [ $DARK_MODE = "1" ] ; then
 fi
 
 IMAGE_TO_USE="$FULL_FILENAME"
+
+# Crop the image around the center if required
+if [[ $CROP_IMAGE == "true" ]]; then
+        convert "$IMAGE_TO_USE" -gravity Center -crop "$CROP_WIDTH"x"$CROP_HEIGHT"+"$CROP_OFFSET_X"+"$CROP_OFFSET_Y" +repage "$IMAGE_TO_USE";
+fi
+
 cp $IMAGE_TO_USE "liveview-$FILENAME.$EXTENSION"
 
 

--- a/scripts/saveImageNight.sh
+++ b/scripts/saveImageNight.sh
@@ -25,6 +25,11 @@ if [ "$DARK_FRAME_SUBTRACTION" = true ] ; then
 	IMAGE_TO_USE="$FILENAME-processed.$EXTENSION"
 fi
 
+# Crop the image around the center if required
+if [[ $CROP_IMAGE == "true" ]]; then
+        convert "$IMAGE_TO_USE" -gravity Center -crop "$CROP_WIDTH"x"$CROP_HEIGHT"+"$CROP_OFFSET_X"+"$CROP_OFFSET_Y" +repage "$IMAGE_TO_USE";
+fi
+
 #Uncomment the following line to enable image stretching
 #convert $IMAGE_TO_USE -sigmoidal-contrast 10,10% $IMAGE_TO_USE
 cp $IMAGE_TO_USE "liveview-$FILENAME.$EXTENSION"


### PR DESCRIPTION
Add config options to crop the captured image. This allows you to remove a lot of the dead space when using fisheye lenses.

Whilst this can be done by editing the scripts manually this makes future updates harder for less experienced people.

The crop is applied BEFORE any other processing so all resulting functions, star trails etc will use the cropped image