### PR TITLE
Fix MIME-type for css files

### DIFF
--- a/gui/lighttpd.conf
+++ b/gui/lighttpd.conf
@@ -42,6 +42,8 @@ static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 compress.cache-dir          = "/var/cache/lighttpd/compress/"
 compress.filetype           = ( "application/javascript", "text/css", "text/html", "text/plain" )
 
+mimetype.assign             = (".css" => "text/css", )
+
 # default listening port for IPv6 falls back to the IPv4 port
 include_shell "/usr/share/lighttpd/use-ipv6.pl " + server.port
 include_shell "/usr/share/lighttpd/create-mime.conf.pl"


### PR DESCRIPTION
Fixes lighttpd.conf so that the server transmits the MIME type of the css files correctly.

Some browsers will otherwise not load the css files and the webpage will not be displayed correctly.