### PR TITLE
Added extra text options

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ nano settings.json
 | filename | image.jpg | this is the name used across the app. Supported extensions are JPG and PNG. |
 | flip | 0 | 0=Original, 1=Horizontal, 2=Vertical, 3=Both |
 | text | text | Text overlay. **Note**: It is replaced by timestamp if time=1 |
+| extratext | | (ZWO ONLY) The FULL path to a text file which will be displayed under the Exposure/Gain. The file can contain multiple lines which will be displayed underneath each other |
+| extratextage | 600 | (ZWO ONLY) If using the extra text file then it must be updated within this number of seconds, if not it will not be displayed. Set to 0 to ignore this check and always didplay it |
+| textlineheight | 30 | (ZWO ONLY) The line height of the text displayed in the image, if you chnage the font size the adjust this value if required |
 | textx | 15 | Horizontal text placement from the left |
 | texty | 35 | Vertical text placement from the top |
 | fontname | 0 | Font type for the overlay. 0=Simplex, 1=Plain, 2=Duplex, 3=Complex, 4=Triplex, 5=Complex small, 6=Script simplex, 7=Script complex |


### PR DESCRIPTION
Adds three new fields to the camera config (To be used in conjunction with the PR on the allsky-portal repo)

- extratext - The full path to a file containing the extra text to be displayed on the images. The file can contain multiple lines, each will be displayed.
- extratextage - If the file above is not updated within this timeframe then the contents of the text file will not be added to the images, handy for when the process updating the text file crashes. To disable this check set the value to 0
- textlineheight - Allows the line height of the text to be changed, saves people manually editing and recompiling capture.cpp

- Fixed a few issues with name and std library clashes (renamed time to showTime)
- Fixed a bug with the command line parser if a text value was missing
- Added a debug option (-debuglevel) for running in foreground. If set to 0, the default then the exiting text display is maintained. This option has to be manually added and is not set by the camera config
- Added a few missing values to the startup output

- Updated readme

Did a full reinstall on a new Pi to test and seems to work ok, had to modify the gui install script to pull from my branch for the test but I am sure thats ok :-)