### PR TITLE
Allow name of Pi to be specified for GUI install

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,17 @@ If you are using a desktop environment (Pixel, Mate, LXDE, etc) or using remote 
 ![](http://www.thomasjacquin.com/allsky-portal/screenshots/camera-settings.jpg)
 
 If you don't want to configure the camera using the terminal, you can install the web based [graphical interface](https://github.com/thomasjacquin/allsky-portal).
-Please note that this will change your hostname to allsky, install lighttpd and replace your /var/www/html directory. It will also move settings.json to `/etc/raspap/settings.json`.
+Please note that this will change your hostname to allsky (or whatever you called it when installing), install lighttpd and replace your /var/www/html directory. It will also move settings.json to `/etc/raspap/settings.json`.
 
 ```shell
 sudo gui/install.sh
 ```
+Or if you don't want to use the default name of 'allsky' for your pi use the following
+
+```shell
+sudo gui/install.sh piname
+```
+
 **Note:*** If you use an older version of Raspbian, the install script may fail on php7.0-cgi dependency. Edit gui/install.sh and replace php7.0-cgi by php5-cgi.
 
 After you complete the GUI setup, you'll be able to administer the camera using the web UI by navigating to
@@ -205,6 +211,11 @@ http://your_raspberry_IP
 or
 ```sh
 http://allsky.local
+```
+
+Note: If you changed the name of your pi during the gui install then use
+```sh
+http://piname.local
 ```
 
 The default username is 'admin' and the default password is 'secret'.

--- a/gui/install.sh
+++ b/gui/install.sh
@@ -2,6 +2,14 @@
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
+
+if [ $# -eq 1 ] ; then
+	HOST_NAME=$1
+else
+	HOST_NAME='allsky'
+fi
+
+
 echo -en '\n'
 echo -e "${RED}****************************************************************"
 echo    "*** Welcome to the Allsky Administration Portal installation ***"
@@ -23,8 +31,8 @@ sed -i "s|/home/pi/allsky|$(dirname "$SCRIPTPATH")|g" $SCRIPTPATH/lighttpd.conf
 cp $SCRIPTPATH/lighttpd.conf /etc/lighttpd/lighttpd.conf
 echo -en '\n'
 echo -e "${GREEN}* Changing hostname to allsky${NC}"
-echo "allsky" > /etc/hostname
-sed -i 's/raspberrypi/allsky/g' /etc/hosts
+echo "$HOST_NAME" > /etc/hostname
+sed -i 's/raspberrypi/$HOST_NAME/g' /etc/hosts
 echo -en '\n'
 echo -e "${GREEN}* Setting avahi-daemon configuration${NC}"
 cp $SCRIPTPATH/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
@@ -53,7 +61,7 @@ sed -i '/CAMERA_SETTINGS_DIR=/c\CAMERA_SETTINGS_DIR="/etc/raspap"' $(dirname "$S
 echo -en '\n'
 echo -en '\n'
 echo "The Allsky Portal is now installed"
-echo "You can now reboot the Raspberry Pi and connect to it from your laptop, computer, phone, tablet at this address: http://allsky.local or http://`ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p'`"
+echo "You can now reboot the Raspberry Pi and connect to it from your laptop, computer, phone, tablet at this address: http://$HOST_NAME.local or http://`ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p'`"
 echo -en '\n'
 read -p "Do you want to reboot now? [y/n] " ans_yn
 case "$ans_yn" in


### PR DESCRIPTION
Since I have multiple installations I needed a way to prevent the gui nameing all of them 'allsky'.
This change allows the hostname to be specified when installing the GUI. If no name is specified then the default 'allsky' is used.
Tested on a clean pi after installing allsky. Also re run the gui installer several times to confirm the hostname changes correctly.