### PR TITLE
Add camera auto-select mode

### DIFF
--- a/allsky.sh
+++ b/allsky.sh
@@ -5,6 +5,8 @@ then
       export ALLSKY_HOME="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 fi
 
+# reset auto camera selection, so $ALLSKY_HOME/config.sh do not pick up old camera selection
+echo "" > "$CAMERA_SETTINGS_DIR/autocam.sh"
 source $ALLSKY_HOME/config.sh
 
 echo "Making sure allsky.sh is not already running..."
@@ -52,6 +54,8 @@ fi
 echo "Settings check done"
 echo "CAMERA: ${CAMERA}"
 echo "CAMERA_SETTINGS: ${CAMERA_SETTINGS}"
+# save auto camera selection for the current session, will be read in "$ALLSKY_HOME/config.sh" file
+echo "export CAMERA=$CAMERA" > "$CAMERA_SETTINGS_DIR/autocam.sh"
 
 # this must be called after camera autoselect
 source $ALLSKY_HOME/scripts/filename.sh

--- a/allsky.sh
+++ b/allsky.sh
@@ -6,24 +6,55 @@ then
 fi
 
 source $ALLSKY_HOME/config.sh
-source $ALLSKY_HOME/scripts/filename.sh
 
 echo "Making sure allsky.sh is not already running..."
 ps -ef | grep allsky.sh | grep -v $$ | xargs "sudo kill -9" 2>/dev/null
 
 RPiHQIsPresent=$(vcgencmd get_camera)
+ZWOIsPresent=$(lsusb -D $(lsusb | awk '/ 03c3:/ { bus=$2; dev=$4; gsub(/[^0-9]/,"",dev); print "/dev/bus/usb/"bus"/"dev;}') | grep -c 'iProduct .*ASI[0-9]')
+
+# regular flow, to exist if no selected camera was found
 if [[ $CAMERA == "RPiHQ" && $RPiHQIsPresent != "supported=1 detected=1" ]]; then
 echo "RPiHQ Camera not found. Exiting." >&2
         sudo systemctl stop allsky
         exit 0
 fi
 
-ZWOIsPresent=$(lsusb -D $(lsusb | awk '/ 03c3:/ { bus=$2; dev=$4; gsub(/[^0-9]/,"",dev); print "/dev/bus/usb/"bus"/"dev;}') | grep -c 'iProduct .*ASI[0-9]')
 if [[ $CAMERA == "ZWO" &&  $ZWOIsPresent -eq 0 ]]; then
         echo "ZWO Camera not found. Exiting." >&2
         sudo systemctl stop allsky
         exit 0
 fi
+
+# CAMERA AUTOSELECT
+# exit if no camare found at all
+if [[ $CAMERA -eq "auto" ]]; then
+  echo "Trying to automatically choose between ZWO and RPI camera"
+  if [[ $ZWOIsPresent -eq 0 && $RPiHQIsPresent != "supported=1 detected=1" ]]; then
+          echo "None of RPI or ZWO Cameras were found. Exiting." >&2
+          sudo systemctl stop allsky
+          exit 0
+  fi
+  # prioritize ZWO camera if exists, and use RPI camera otherwise
+  if [[ $ZWOIsPresent -eq 0 ]]; then
+    echo "No ZWO camera found. Choosing RPI"
+    CAMERA="RPiHQ"
+  else
+    echo "ZWO camera found. Choosing ZWO"
+    CAMERA="ZWO"
+  fi
+
+  # redefine the settings variable
+  CAMERA_SETTINGS="$CAMERA_SETTINGS_DIR/settings_$CAMERA.json"
+fi
+
+
+echo "Settings check done"
+echo "CAMERA: ${CAMERA}"
+echo "CAMERA_SETTINGS: ${CAMERA_SETTINGS}"
+
+# this must be called after camera autoselect
+source $ALLSKY_HOME/scripts/filename.sh
 
 echo "Starting allsky camera..."
 cd $ALLSKY_HOME

--- a/allsky.sh
+++ b/allsky.sh
@@ -6,7 +6,7 @@ then
 fi
 
 # reset auto camera selection, so $ALLSKY_HOME/config.sh do not pick up old camera selection
-echo "" > "$CAMERA_SETTINGS_DIR/autocam.sh"
+echo "" > "$ALLSKY_HOME/autocam.sh"
 source $ALLSKY_HOME/config.sh
 
 echo "Making sure allsky.sh is not already running..."

--- a/allsky.sh
+++ b/allsky.sh
@@ -12,16 +12,15 @@ source $ALLSKY_HOME/config.sh
 echo "Making sure allsky.sh is not already running..."
 ps -ef | grep allsky.sh | grep -v $$ | xargs "sudo kill -9" 2>/dev/null
 
+# old/regular manual camera selection mode => exit if no requested camera was found
 RPiHQIsPresent=$(vcgencmd get_camera)
-ZWOIsPresent=$(lsusb -D $(lsusb | awk '/ 03c3:/ { bus=$2; dev=$4; gsub(/[^0-9]/,"",dev); print "/dev/bus/usb/"bus"/"dev;}') | grep -c 'iProduct .*ASI[0-9]')
-
-# regular flow, to exist if no selected camera was found
 if [[ $CAMERA == "RPiHQ" && $RPiHQIsPresent != "supported=1 detected=1" ]]; then
 echo "RPiHQ Camera not found. Exiting." >&2
         sudo systemctl stop allsky
         exit 0
 fi
 
+ZWOIsPresent=$(lsusb -D $(lsusb | awk '/ 03c3:/ { bus=$2; dev=$4; gsub(/[^0-9]/,"",dev); print "/dev/bus/usb/"bus"/"dev;}') | grep -c 'iProduct .*ASI[0-9]')
 if [[ $CAMERA == "ZWO" &&  $ZWOIsPresent -eq 0 ]]; then
         echo "ZWO Camera not found. Exiting." >&2
         sudo systemctl stop allsky

--- a/autocam.sh
+++ b/autocam.sh
@@ -1,0 +1,1 @@
+export CAMERA=ZWO

--- a/autostart/allsky.service
+++ b/autostart/allsky.service
@@ -5,7 +5,7 @@ After=multi-user.target
 [Service]
 User=pi
 ExecStart=/home/pi/allsky/allsky.sh
-StandardOutput=null
+StandardOutput=syslog
 StandardError=syslog
 SyslogFacility=local5
 Restart=always

--- a/config.sh.repo
+++ b/config.sh.repo
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Choose between ZWO or RPiHQ
-CAMERA="ZWO"
+# Choose between ZWO or RPiHQ or auto (prefers ZWO if present)
+CAMERA="auto"
+
 
 # Set to true to upload current image to your website
 UPLOAD_IMG=false
@@ -62,4 +63,9 @@ AUTO_STRETCH_MID_POINT=10%
 
 # Path to the camera settings (exposure, gain, delay, overlay, etc)
 CAMERA_SETTINGS_DIR="$ALLSKY_HOME"
+
+if [[ $CAMERA -eq "auto" ]]; then
+  # restore currently saved autodiscovered camera mode if any
+  source "$CAMERA_SETTINGS_DIR/autocam.sh"
+fi
 CAMERA_SETTINGS="$CAMERA_SETTINGS_DIR/settings_$CAMERA.json"


### PR DESCRIPTION
e.g. useful for faster/easier setup using defaults, or if one has both cameras as uses headless mode. 
@thomasjacquin 

RPI camera is pretty bad, so quite obviously default should be ZWO.

seem to work ok.