### PR TITLE
Added scaling option to save disk space

### DIFF
--- a/config.sh.repo
+++ b/config.sh.repo
@@ -48,6 +48,11 @@ DAYTIME="1"
 # Set 24Hr capture to true to save both night and day images to disk. By default, only night images are saved.
 CAPTURE_24HR=false
 
+# Resize images before cropping and saving
+IMG_RESIZE=true
+IMG_HEIGHT=1520
+IMG_WIDTH=2028
+
 # Crop the captured image, used to improve the images when using a fisheye lens
 CROP_IMAGE=false
 CROP_WIDTH=640

--- a/scripts/saveImageDay.sh
+++ b/scripts/saveImageDay.sh
@@ -15,6 +15,11 @@ fi
 
 IMAGE_TO_USE="$FULL_FILENAME"
 
+# Resize the image if required
+if [[ $IMG_RESIZE == "true" ]]; then
+        convert "$IMAGE_TO_USE" -resize "$IMG_WIDTH"x"$IMG_HEIGHT" $IMAGE_TO_USE
+fi
+
 # Crop the image around the center if required
 if [[ $CROP_IMAGE == "true" ]]; then
         convert "$IMAGE_TO_USE" -gravity Center -crop "$CROP_WIDTH"x"$CROP_HEIGHT"+"$CROP_OFFSET_X"+"$CROP_OFFSET_Y" +repage "$IMAGE_TO_USE";

--- a/scripts/saveImageNight.sh
+++ b/scripts/saveImageNight.sh
@@ -26,6 +26,11 @@ if [ "$DARK_FRAME_SUBTRACTION" = true ] ; then
 	IMAGE_TO_USE="$FILENAME-processed.$EXTENSION"
 fi
 
+# Resize the image if required
+if [[ $IMG_RESIZE == "true" ]]; then
+        convert "$IMAGE_TO_USE" -resize "$IMG_WIDTH"x"$IMG_HEIGHT" $IMAGE_TO_USE
+fi
+
 # Crop the image around the center if required
 if [[ $CROP_IMAGE == "true" ]]; then
         convert "$IMAGE_TO_USE" -gravity Center -crop "$CROP_WIDTH"x"$CROP_HEIGHT"+"$CROP_OFFSET_X"+"$CROP_OFFSET_Y" +repage "$IMAGE_TO_USE";


### PR DESCRIPTION
Hi Thomas,

Files of the Pi HQ cam are quite large (about 5+ MB). First, I tried the 2x2 binning option so save some space but that generated quite strange artifacts and especially a hot pixel that is not there when not using binning. You can get rid of it with dark frame subtraction, but only for some time - it seems to move and then leaves a black spot with a new hot pixel next to it in the binned image.

As this effect doesn't occur when using the full resolution (1x1 binning) and I even don't have hot pixels at all in that mode (on-chip dead-pixel correction is switched on), I added an option to scale down the picture before saving it in the daily folder. Reducing the image size by a factor of 2 leaves me with individual images of around 1,3 MB each - and with no artifacts or hot pixels, and no urgent need for darks. Additionally, switching on binning seems to dramatically reduce sensitivity of my HQ cam - not that I understand that ;-)

Maybe you want to add it to your version.

Stefan 