### PR TITLE
Ignore settings_*.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ scripts/keogram_only.sh
 scripts/startrails_manual.sh
 scripts/startrails_only.sh
 scripts/stretch.sh
+settings_RPiHQ.json
+settings_ZWO.json


### PR DESCRIPTION
Want the camera config json files to stop showing up as untracked files.