### PR TITLE
Only archive night darks

### DIFF
--- a/scripts/darkCapture.sh
+++ b/scripts/darkCapture.sh
@@ -14,8 +14,14 @@ else
 fi
 
 if [ $DARK_MODE = "1" ] ; then
-        mkdir -p darks
-        cp $FULL_FILENAME "darks/$TEMP.$EXTENSION"
+        # Determine sourcing script, to detect day or night mode
+        PARENT_SCRIPT=$(basename ${BASH_SOURCE[1]})
+
+        # Only archive night darks
+        if [ "$PARENT_SCRIPT" == "saveImageNight.sh" ] ; then
+                mkdir -p darks
+                cp $FULL_FILENAME "darks/$TEMP.$EXTENSION"
+        fi
         cp $FULL_FILENAME "liveview-$FILENAME.$EXTENSION"
         exit 0
 fi


### PR DESCRIPTION
Updates `darkCapture.sh` to only archive darks acquired in "night" mode.  This prevents day mode (with different exposure settings) from over-writing darks gathered at the same temperature.

This should improve collection of darks and night-time exposures, while having no effect on daytime capture, as `saveImageDay.sh` does not call `darkSubtract.sh`.