### PR TITLE
Add -newexposure option based on issue 417

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ nano settings_RPiHQ.json  or  nano settings_ZWO.json
 | showBrightness | 1 | Display the brightness level in the overlay? |
 | darkframe | 0 | Set to 1 to enable dark frame capture. In this mode, overlays are hidden. |
 | notificationimages | 1 | Set to 0 to disable notification images, e.g., "Camera off during day" if daytime images are not being taken. |
-| newexposure | 1 | Determines if the new version 0.8 exposure method... If you see ASI_ERROR_TIMEOUTs" in the log file, try setting this to 0. ( See [issue 417](https://github.com/thomasjacquin/allsky/issues/417) ) |
+| newexposure | 1 | Determines if the new version 0.8 exposure method is used. If you see ASI_ERROR_TIMEOUTs" in the log file, try setting this to 0. ( See [issue 417](https://github.com/thomasjacquin/allsky/issues/417) ) |
 | debuglevel | 0 | Determines the amount of output in the log file (usually /var/log/allsky.log). |
 
 The second file called **config.sh** lets you configure the overall behavior of the camera. Options include functionalities such as upload, timelapse, dark frame location, keogram.  Note that with the administrative GUI, you can edit the file via the "Editor" link on the left side of the page.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In order to get the camera working properly you will need the following hardware
  * A camera (Tested cameras include Raspberry Pi HQ camera, ASI120MC*, ASI120MM*, ASI120MC-S, ASI120MM-S, ASI224MC, ASI178MC, ASI185MC, ASI290MC, ASI1600MC
  * A Raspberry Pi (2, 3, 4 or Zero)
 
-**Note:*** Owners of USB2.0 cameras such as ASI120MC and ASI120MM may need to do a [firmware upgrade](https://astronomy-imaging-camera.com/software/) (This changes the camera to use 512 byte packets instead of 1024 which makes it more compatible with most hardware.)
+**Note:*** Owners of USB2.0 cameras such as ASI120MC and ASI120MM may need to do a [firmware upgrade](https://astronomy-imaging-camera.com/software-drivers) (This changes the camera to use 512 byte packets instead of 1024 which makes it more compatible with most hardware.)
 
 The Datyson T7 camera seems to be supported as well. The firmware needs to be upgraded with ZWO's compatible firmware (see link above) and you'll need to add this line in /boot/config.txt: `program_usb_boot_mode=0`
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ nano settings_RPiHQ.json  or  nano settings_ZWO.json
 | showBrightness | 1 | Display the brightness level in the overlay? |
 | darkframe | 0 | Set to 1 to enable dark frame capture. In this mode, overlays are hidden. |
 | notificationimages | 1 | Set to 0 to disable notification images, e.g., "Camera off during day" if daytime images are not being taken. |
+| newexposure | 1 | Determines if the new exposure method is used ( fixes [issue 417](https://github.com/thomasjacquin/allsky/issues/417) ) |
 | debuglevel | 0 | Determines the amount of output in the log file (usually /var/log/allsky.log). |
 
 The second file called **config.sh** lets you configure the overall behavior of the camera. Options include functionalities such as upload, timelapse, dark frame location, keogram.  Note that with the administrative GUI, you can edit the file via the "Editor" link on the left side of the page.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ nano settings_RPiHQ.json  or  nano settings_ZWO.json
 | showBrightness | 1 | Display the brightness level in the overlay? |
 | darkframe | 0 | Set to 1 to enable dark frame capture. In this mode, overlays are hidden. |
 | notificationimages | 1 | Set to 0 to disable notification images, e.g., "Camera off during day" if daytime images are not being taken. |
-| newexposure | 1 | Determines if the new exposure method is used ( fixes [issue 417](https://github.com/thomasjacquin/allsky/issues/417) ) |
+| newexposure | 1 | Determines if the new version 0.8 exposure method... If you see ASI_ERROR_TIMEOUTs" in the log file, try setting this to 0. ( See [issue 417](https://github.com/thomasjacquin/allsky/issues/417) ) |
 | debuglevel | 0 | Determines the amount of output in the log file (usually /var/log/allsky.log). |
 
 The second file called **config.sh** lets you configure the overall behavior of the camera. Options include functionalities such as upload, timelapse, dark frame location, keogram.  Note that with the administrative GUI, you can edit the file via the "Editor" link on the left side of the page.

--- a/capture.cpp
+++ b/capture.cpp
@@ -46,6 +46,7 @@
 
 cv::Mat pRgb;
 std::vector<int> compression_parameters;
+bool use_new_exposure_algorithm = true;
 bool bMain = true, bDisplay = false;
 std::string dayOrNight;
 
@@ -454,6 +455,13 @@ ASI_ERROR_CODE takeOneExposure(
 
     setControl(cameraId, ASI_EXPOSURE, exposureTimeMicroseconds, currentAutoExposure);
 
+    if (use_new_exposure_algorithm)
+    {
+        status = ASIStartVideoCapture(cameraId);
+    } else {
+        status = ASI_SUCCESS;
+    }
+
     status = ASIStartVideoCapture(cameraId);
     if (status == ASI_SUCCESS) {
         status = ASIGetVideoData(cameraId, imageBuffer, bufferSize, timeout);
@@ -477,6 +485,10 @@ ASI_ERROR_CODE takeOneExposure(
             ASIGetControlValue(cameraId, ASI_TEMPERATURE, &actualTemp, &bAuto);
         }
         ASIStopVideoCapture(cameraId);
+
+        if (use_new_exposure_algorithm)
+            ASIStopVideoCapture(cameraId);
+
     }
     else {
         sprintf(debugText, "  > ERROR: Not fetching exposure data because status is %s\n", getRetCode(status));
@@ -970,6 +982,13 @@ const char *locale = DEFAULT_LOCALE;
             if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "-help") == 0)
             {
                 help = 1;
+            }
+            else if (strcmp(argv[i], "-newexposure") == 0)
+            {
+                if (atoi(argv[++i]))
+                    use_new_exposure_algorithm = true;
+                else
+                    use_new_exposure_algorithm = false;
             }
             else if (strcmp(argv[i], "-locale") == 0)
             {


### PR DESCRIPTION
Based on code update provided in [comment](https://github.com/thomasjacquin/allsky/issues/417#issuecomment-906830896) by [EricClaeys](https://github.com/EricClaeys).  This allows reverting back to the 'v7' exposure method fixing [issue 417](https://github.com/thomasjacquin/allsky/issues/417).

Includes README.md documentation of the option.