### PR TITLE
emit debug message when buffer clearing fails

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -1954,6 +1954,8 @@ const char *locale = DEFAULT_LOCALE;
                 asiRetCode = takeOneExposure(CamNum, SHORT_EXPOSURE, pRgb.data, width, height, (ASI_IMG_TYPE) Image_type);
                 if (asiRetCode != ASI_SUCCESS)
                 {
+                    sprintf(debugText, "buffer clearing exposure %d failed: %s\n", i, getRetCode(asiRetCode));
+                    displayDebugText(debugText, 0);
                     numErrors++;
                     sleep(2);	// sometimes sleeping keeps errors from reappearing
                 }


### PR DESCRIPTION
At least this way I know when the trash frame exposures fail, and why... rather than getting a silent failure