### PR TITLE
unbreak ROI selection

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -1537,9 +1537,11 @@ const char *locale = DEFAULT_LOCALE;
 
     if (width == 0 || height == 0)
     {
-        width  = iMaxWidth;	originalWidth = width;
-        height = iMaxHeight;	originalHeight = height;
+        width  = iMaxWidth;
+        height = iMaxHeight;
     }
+    originalWidth = width;
+    originalHeight = height;
 
     ASIGetControlValue(CamNum, ASI_TEMPERATURE, &actualTemp, &bAuto);
     printf("- Sensor temperature:%0.2f\n", (float)actualTemp / 10.0);
@@ -1931,7 +1933,9 @@ const char *locale = DEFAULT_LOCALE;
             pRgb.create(cvSize(width, height), CV_8UC1);
         }
 
-        ASISetROIFormat(CamNum, width, height, currentBin, (ASI_IMG_TYPE)Image_type);
+        asiRetCode = ASISetROIFormat(CamNum, width, height, currentBin, (ASI_IMG_TYPE)Image_type);
+        if (asiRetCode)
+			printf("ASISetROIFormat(%d, %dx%d, %d, %d) = %s\n", CamNum, width, height, currentBin, Image_type, getRetCode(asiRetCode));
         setControl(CamNum, ASI_BRIGHTNESS, currentBrightness, ASI_FALSE); // ASI_BRIGHTNESS == ASI_OFFSET
 
         // Here and below, indent sub-messages with "  > " so it's clear they go with the un-indented line.

--- a/capture.cpp
+++ b/capture.cpp
@@ -1935,7 +1935,10 @@ const char *locale = DEFAULT_LOCALE;
 
         asiRetCode = ASISetROIFormat(CamNum, width, height, currentBin, (ASI_IMG_TYPE)Image_type);
         if (asiRetCode)
+        {
 			printf("ASISetROIFormat(%d, %dx%d, %d, %d) = %s\n", CamNum, width, height, currentBin, Image_type, getRetCode(asiRetCode));
+			closeUp(1);
+        }
         setControl(CamNum, ASI_BRIGHTNESS, currentBrightness, ASI_FALSE); // ASI_BRIGHTNESS == ASI_OFFSET
 
         // Here and below, indent sub-messages with "  > " so it's clear they go with the un-indented line.


### PR DESCRIPTION
New exposure mode did not correctly set the capture ROI if the image size was manually specified. It was calling SetROI with a 0x0 window which would cause subsequent captures to fail.

At least partially fixes #471 

cc @EricClaeys 