### PR TITLE
increase USB timeout

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -447,8 +447,9 @@ ASI_ERROR_CODE takeOneExposure(
 
     ASI_ERROR_CODE status;
     // ZWO recommends timeout = (exposure*2) + 500 ms
-    // 1500ms seems better with lots of other USB traffic (eg. disk IO)
-    long timeout = ((exposureTimeMicroseconds * 2) / US_IN_MS) + 1500;	// timeout is in ms
+    // After some discussion, we're doing +5000ms to account for delays induced by
+	// USB contention, such as that caused by heavy USB disk IO
+    long timeout = ((exposureTimeMicroseconds * 2) / US_IN_MS) + 5000;	// timeout is in ms
 
     sprintf(debugText, "  > Exposure set to %'ld Âµs (%'.2f ms), timeout: %'ld ms\n",
             exposureTimeMicroseconds, (float)exposureTimeMicroseconds/US_IN_MS, timeout);

--- a/capture.cpp
+++ b/capture.cpp
@@ -447,7 +447,8 @@ ASI_ERROR_CODE takeOneExposure(
 
     ASI_ERROR_CODE status;
     // ZWO recommends timeout = (exposure*2) + 500 ms
-    long timeout = ((exposureTimeMicroseconds * 2) / US_IN_MS) + 500;	// timeout is in ms
+    // 1500ms seems better with lots of other USB traffic (eg. disk IO)
+    long timeout = ((exposureTimeMicroseconds * 2) / US_IN_MS) + 1500;	// timeout is in ms
 
     sprintf(debugText, "  > Exposure set to %'ld Âµs (%'.2f ms), timeout: %'ld ms\n",
             exposureTimeMicroseconds, (float)exposureTimeMicroseconds/US_IN_MS, timeout);


### PR DESCRIPTION
Doing a bunch of USB disk IO was killin' the capture on my rPi. Bumping
up to 1500ms allowed capture to run successfully while copying lots of
data.