### PR TITLE
Make it easier to reprocess images on other machines

### DIFF
--- a/config.sh.repo
+++ b/config.sh.repo
@@ -25,6 +25,9 @@ TIMELAPSE_BITRATE="2000k"
 # Timelapse frame rate (number of frames per second)
 FPS=25
 
+# Encoder for timelapse. May be changed to use a hardware encoder or different codec
+VCODEC=libx264
+
 # Set to true to generate a keogram at the end of the night (image summary of the night)
 KEOGRAM=true
 

--- a/scripts/timelapse.sh
+++ b/scripts/timelapse.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
+
+if [ -z "$ALLSKY_HOME" ] ; then
+	export ALLSKY_HOME=$(realpath $(dirname "$BASH_ARGV0")/..)
+fi
+
 source $ALLSKY_HOME/config.sh
 source $ALLSKY_HOME/scripts/filename.sh
 source $ALLSKY_HOME/scripts/ftp-settings.sh
 
 cd $ALLSKY_HOME
-
-FPS=${FPS:-25}
-ENCODER=${ENCODER:-libx264}
 
 ME="$(basename "$BASH_ARGV0")"	# Include script name in output so it's easier to find in the log file
 
@@ -71,11 +73,12 @@ fi
 
 # "-loglevel warning" gets rid of the dozens of lines of garbage output
 # but doesn't get rid of "deprecated pixel format" message when -pix_ftm is "yuv420p".
+# set FFLOG=info in config.sh if you want to see what's going on for debugging
 ffmpeg -y -f image2 \
-	-loglevel warning \
-	-r $FPS \
+	-loglevel ${FFLOG:-warning} \
+	-r ${FPS:-25} \
 	-i $DIR/sequence/%04d.$EXTENSION \
-	-vcodec libx264 \
+	-vcodec ${VCODEC:libx264} \
 	-b:v ${TIMELAPSE_BITRATE:-2000k} \
 	-pix_fmt yuv420p \
 	-movflags +faststart \

--- a/scripts/timelapse.sh
+++ b/scripts/timelapse.sh
@@ -34,6 +34,14 @@ else
 	DIR="$2"
 fi
 
+# Guess what the likely image extension is (unless specified in the config) by
+# looking at the most common extension in the target day directory
+if [ -z "$EXTENSION" ] ; then
+	EXT_GUESS=$(ls $DIR | sed -e 's/.*[.]//' | sort | uniq -c | head -1 | sed -e 's/.* //')
+    echo -en "${RED}${ME}: file EXTENSION not found in configuration, guessing ${EXT_GUESS}${NC}\n"
+	EXTENSION=$EXT_GUESS
+fi
+
 # If you are tuning encoder settings, run this script with KEEP_SEQUENCE, eg.
 #	$ env KEEP_SEQUENCE=1 VCODEC=h264_nvenc ~/allsky/scripts/timelapse.sh ${TODAY} /media/external/allsky/${TODAY}/
 # to keep the sequence directory from being deleted and to reuse the contents

--- a/scripts/timelapse.sh
+++ b/scripts/timelapse.sh
@@ -48,7 +48,7 @@ fi
 # of the sequence directory if it looks ok (contains at least 100 files). This
 # might save you some time when running your encoder repeatedly.
 
-NSEQ=$(ls "/${DIR}/sequence" | wc -l )
+NSEQ=$(ls "/${DIR}/sequence" 2>/dev/null | wc -l )
 if [ -z "$KEEP_SEQUENCE" -o $NSEQ -lt 100 ] ; then
 	echo -en "${ME}: ${GREEN}Creating symlinks to generate timelapse${NC}\n"
 	rm -fr $DIR/sequence

--- a/scripts/timelapse.sh
+++ b/scripts/timelapse.sh
@@ -5,17 +5,21 @@ source $ALLSKY_HOME/scripts/ftp-settings.sh
 
 cd $ALLSKY_HOME
 
+FPS=${FPS:-25}
+ENCODER=${ENCODER:-libx264}
+
 ME="$(basename "$BASH_ARGV0")"	# Include script name in output so it's easier to find in the log file
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
-if [ $# -lt 1 ]
-  then
-    echo -en "${ME}: ${RED}You need to pass a day argument\n"
-        echo -en "    ex: timelapse.sh 20180119${NC}\n"
-        exit 3
+if [ $# -lt 1 -o $# -gt 2 -o "x$1" = "x-h" ] ; then
+    TODAY=$(date +%Y%m%d)
+    echo -en "${RED}Usage: ${ME} <day> [directory]${NC}\n"
+    echo -en "    ex: timelapse.sh ${TODAY}\n"
+    echo -en "    or: timelapse.sh ${TODAY} /media/external/allsky/${TODAY}\n"
+    exit 3
 fi
 
 # Allow timelapses of pictures not in ALLSKY_HOME.
@@ -27,7 +31,7 @@ else
 	DIR="$2"
 fi
 echo -en "${ME}: ${GREEN}Creating symlinks to generate timelapse${NC}\n"
-[ -d $DIR/sequence ] && rm -fr $DIR/sequence	# remove in case it was left over from last run
+rm -fr $DIR/sequence	# remove in case it was left over from last run
 mkdir -p $DIR/sequence/
 
 # find images, make symlinks sequentially and start avconv to build mp4; upload mp4 and move directory

--- a/scripts/timelapse.sh
+++ b/scripts/timelapse.sh
@@ -99,7 +99,7 @@ ffmpeg -y -f image2 \
 	-loglevel ${FFLOG:-warning} \
 	-r ${FPS:-25} \
 	-i $DIR/sequence/%04d.$EXTENSION \
-	-vcodec ${VCODEC:libx264} \
+	-vcodec ${VCODEC:-libx264} \
 	-b:v ${TIMELAPSE_BITRATE:-2000k} \
 	-pix_fmt yuv420p \
 	-movflags +faststart \


### PR DESCRIPTION
`rm -rf /tmp/nonexistent` doesn't fail on nonexistent files, so unconditionally nuke the sequence directory

```
$ rm -rf /tmp/nonexistent && echo that worked
that worked
```

provide some default values for the framerate and encoder, just in case you don't have them in your configs.