### PR TITLE
Fix opencv crash

### DIFF
--- a/keogram.cpp
+++ b/keogram.cpp
@@ -215,6 +215,7 @@ int main(int argc, char* argv[]) {
   cv::Mat accumulated;
 
   int prevHour = -1;
+  int nchan = 0;
 
   for (size_t f = 0; f < files.gl_pathc; f++) {
     cv::Mat imagesrc = cv::imread(files.gl_pathv[f], cv::IMREAD_UNCHANGED);
@@ -230,10 +231,16 @@ int main(int argc, char* argv[]) {
 
     if (height && width &&
         (imagesrc.cols != width || imagesrc.rows != height)) {
-      fprintf(stderr, "Image size %dx%d != %dx%d\n", imagesrc.cols,
-              imagesrc.cols, width, height);
+      fprintf(stderr, "%s size %dx%d != %dx%d\n", files.gl_pathv[f],
+              imagesrc.cols, imagesrc.cols, width, height);
       continue;
     }
+    if (nchan == 0)
+      nchan = imagesrc.channels();
+
+    if (imagesrc.channels() != nchan)
+      continue;
+
     cv::Point2f center((imagesrc.cols - 1) / 2.0, (imagesrc.rows - 1) / 2.0);
     cv::Mat rot = cv::getRotationMatrix2D(center, angle, 1.0);
     cv::Rect2f bbox =

--- a/keogram.cpp
+++ b/keogram.cpp
@@ -108,7 +108,7 @@ int get_font_by_name(char* s) {
 
 int main(int argc, char* argv[]) {
   int c;
-  bool labelsEnabled = true;
+  bool labelsEnabled = true, parse_filename = false;
   int fontFace = cv::FONT_HERSHEY_SCRIPT_SIMPLEX;
   double fontScale = 2;
   int fontType = cv::LINE_8;
@@ -131,12 +131,13 @@ int main(int argc, char* argv[]) {
         {"font-size", required_argument, 0, 'S'},
         {"font-type", required_argument, 0, 'T'},
         {"rotate", required_argument, 0, 'r'},
+        {"parse-filename", no_argument, 0, 'p'},
         {"no-label", no_argument, 0, 'n'},
         {"verbose", no_argument, 0, 'v'},
         {"help", no_argument, 0, 'h'},
         {0, 0, 0, 0}};
 
-    c = getopt_long(argc, argv, "d:e:o:r:s:C:L:N:S:T:nvh", long_options,
+    c = getopt_long(argc, argv, "d:e:o:r:s:C:L:N:S:T:npvh", long_options,
                     &option_index);
     if (c == -1)
       break;
@@ -154,6 +155,9 @@ int main(int argc, char* argv[]) {
       case 'o':
         outputfile = optarg;
         break;
+      case 'p':
+        parse_filename = true;
+        break;
       case 'n':
         labelsEnabled = false;
         break;
@@ -170,12 +174,20 @@ int main(int argc, char* argv[]) {
         loglevel++;
         break;
       case 'C':
+        if (strchr(optarg, ' ')) {
+          int r, g, b;
+          sscanf(optarg, "%d %d %d", &b, &g, &r);
+          fontColor[0] = b & 0xff;
+          fontColor[1] = g & 0xff;
+          fontColor[2] = r & 0xff;
+          break;
+        }
         if (optarg[0] == '#')  // skip '#' if input is like '#coffee'
           optarg++;
         sscanf(optarg, "%06x", &tmp);
-        fontColor[0] = (tmp >> 16) & 0xff;
+        fontColor[0] = tmp & 0xff;
         fontColor[1] = (tmp >> 8) & 0xff;
-        fontColor[2] = tmp & 0xff;
+        fontColor[2] = (tmp >> 16) & 0xff;
         break;
       case 'L':
         thickness = atoi(optarg);
@@ -257,11 +269,23 @@ int main(int argc, char* argv[]) {
     imagedst.col(imagedst.cols / 2).copyTo(accumulated.col(f));
 
     if (labelsEnabled) {
-      struct stat s;
-      stat(files.gl_pathv[f], &s);
+      struct tm ft;  // the time of the file, by any means necessary
+      if (parse_filename) {
+        // engage your safety squints!
+        char* s;
+        s = strrchr(files.gl_pathv[f], '-');
+        s++;
+        sscanf(s, "%04d%02d%02d%02d%02d%02d.%*s", &ft.tm_year, &ft.tm_mon,
+               &ft.tm_mday, &ft.tm_hour, &ft.tm_min, &ft.tm_sec);
+      } else {
+        // sometimes you can believe the file time on disk
+        struct stat s;
+        stat(files.gl_pathv[f], &s);
+        struct tm* t = localtime(&s.st_mtime);
+        ft.tm_hour = t->tm_hour;
+      }
 
-      struct tm* t = localtime(&s.st_mtime);
-      if (t->tm_hour != prevHour) {
+      if (ft.tm_hour != prevHour) {
         if (prevHour != -1) {
           // Draw a dashed line and label for hour
           cv::LineIterator it(accumulated, cv::Point(f, 0),
@@ -279,7 +303,7 @@ int main(int argc, char* argv[]) {
 
           // Draw text label to the left of the dash
           char hour[3];
-          snprintf(hour, 3, "%02d", t->tm_hour);
+          snprintf(hour, 3, "%02d", ft.tm_hour);
           std::string text(hour);
           int baseline = 0;
           cv::Size textSize =
@@ -294,7 +318,7 @@ int main(int argc, char* argv[]) {
                         thickness, fontType);
           }
         }
-        prevHour = t->tm_hour;
+        prevHour = ft.tm_hour;
       }
     }
   }

--- a/keogram.cpp
+++ b/keogram.cpp
@@ -52,6 +52,9 @@ void usage_and_exit(int x) {
   std::cout << "-r | --rotate <float> : number of degrees to rotate image, "
                "counterclockwise (0)"
             << std::endl;
+  std::cout << "-s | --image-size <int>x<int> : only process images of a given "
+               "size, eg. 1280x960"
+            << std::endl;
   std::cout << "-h | --help : display this help message" << std::endl;
   std::cout << "-v | --verbose : Increase logging verbosity" << std::endl;
   std::cout << "-n | --no-label : Disable hour labels" << std::endl;
@@ -113,11 +116,13 @@ int main(int argc, char* argv[]) {
   unsigned char fontColor[3] = {255, 0, 0};
   double angle = 0;
   std::string directory, extension, outputfile;
+  int width = 0, height = 0;
 
   while (1) {  // getopt loop
     int option_index = 0;
     static struct option long_options[] = {
         {"directory", required_argument, 0, 'd'},
+        {"image-size", required_argument, 0, 's'},
         {"extension", required_argument, 0, 'e'},
         {"output", required_argument, 0, 'o'},
         {"font-color", required_argument, 0, 'C'},
@@ -131,7 +136,7 @@ int main(int argc, char* argv[]) {
         {"help", no_argument, 0, 'h'},
         {0, 0, 0, 0}};
 
-    c = getopt_long(argc, argv, "d:e:o:r:C:L:N:S:T:nvh", long_options,
+    c = getopt_long(argc, argv, "d:e:o:r:s:C:L:N:S:T:nvh", long_options,
                     &option_index);
     if (c == -1)
       break;
@@ -154,6 +159,12 @@ int main(int argc, char* argv[]) {
         break;
       case 'r':
         angle = atof(optarg);
+        break;
+      case 's':
+        sscanf(optarg, "%dx%d", &width, &height);
+        // 122.8Mpx should be enough for anybody.
+        if (height < 0 || height > 9600 || width < 0 || width > 12800)
+          height = width = 0;
         break;
       case 'v':
         loglevel++;
@@ -217,6 +228,12 @@ int main(int argc, char* argv[]) {
       std::cout << "[" << f + 1 << "/" << files.gl_pathc << "] "
                 << basename(files.gl_pathv[f]) << std::endl;
 
+    if (height && width &&
+        (imagesrc.cols != width || imagesrc.rows != height)) {
+      fprintf(stderr, "Image size %dx%d != %dx%d\n", imagesrc.cols,
+              imagesrc.cols, width, height);
+      continue;
+    }
     cv::Point2f center((imagesrc.cols - 1) / 2.0, (imagesrc.rows - 1) / 2.0);
     cv::Mat rot = cv::getRotationMatrix2D(center, angle, 1.0);
     cv::Rect2f bbox =

--- a/startrails.cpp
+++ b/startrails.cpp
@@ -12,8 +12,8 @@
 #include <string>
 #include <vector>
 
-#include <opencv2/imgproc.hpp>
 #include <opencv2/highgui.hpp>
+#include <opencv2/imgproc.hpp>
 
 #define KNRM "\x1B[0m"
 #define KRED "\x1B[31m"

--- a/startrails.cpp
+++ b/startrails.cpp
@@ -62,10 +62,10 @@ void usage_and_exit(int x) {
 int main(int argc, char* argv[]) {
   std::string directory, extension, outputfile;
   double threshold = -1;
-  int verbose = 0, stats_only = 0;
+  int verbose = 0, stats_only = 0, height = 0, width = 0;
   char c;
 
-  while ((c = getopt(argc, argv, "hvsb:d:e:o:")) != -1) {
+  while ((c = getopt(argc, argv, "hvsb:d:e:o:S:")) != -1) {
     switch (c) {
       case 'h':
         usage_and_exit(0);
@@ -76,6 +76,12 @@ int main(int argc, char* argv[]) {
         break;
       case 's':
         stats_only = 1;
+        break;
+      case 'S':
+        sscanf(optarg, "%dx%d", &width, &height);
+        // 122.8Mpx should be enough for anybody.
+        if (height < 0 || height > 9600 || width < 0 || width > 12800)
+          height = width = 0;
         break;
       case 'b':
         double tf;
@@ -128,6 +134,12 @@ int main(int argc, char* argv[]) {
       std::cout << "Error reading file " << basename(files.gl_pathv[f])
                 << std::endl;
       stats.col(f) = 1.0;  // mark as invalid
+      continue;
+    }
+
+    if (height && width && (image.cols != width || image.rows != height)) {
+      fprintf(stderr, "%s size %dx%d != %dx%d\n", files.gl_pathv[f], image.cols,
+              image.cols, width, height);
       continue;
     }
 

--- a/startrails.cpp
+++ b/startrails.cpp
@@ -182,9 +182,9 @@ int main(int argc, char* argv[]) {
           fprintf(stderr, "repairing channel mismatch: %d != %d\n",
                   image.channels(), nchan);
         if (image.channels() < nchan)
-          cv::cvtColor(image, image, CV_GRAY2BGR, nchan);
+          cv::cvtColor(image, image, cv::COLOR_GRAY2BGR, nchan);
         else if (image.channels() > nchan)
-          cv::cvtColor(image, image, CV_BGR2GRAY, nchan);
+          cv::cvtColor(image, image, cv::COLOR_BGR2GRAY, nchan);
       }
       if (accumulated.empty()) {
         image.copyTo(accumulated);

--- a/startrails.cpp
+++ b/startrails.cpp
@@ -48,6 +48,8 @@ void usage_and_exit(int x) {
   std::cout << "-d <str> : directory from which to read images" << std::endl;
   std::cout << "-e <str> : filter images to just this extension" << std::endl;
   std::cout << "-o <str> : output image filename" << std::endl;
+  std::cout << "-S <int>x<int> : restrict processed images to this size"
+            << std::endl;
   std::cout << "-b <float> : ranges from 0 (black) to 1 (white)" << std::endl;
   std::cout << "\tA moonless sky may be as low as 0.05 while full moon can be "
                "as high as 0.4"
@@ -63,7 +65,7 @@ int main(int argc, char* argv[]) {
   std::string directory, extension, outputfile;
   double threshold = -1;
   int verbose = 0, stats_only = 0, height = 0, width = 0;
-  char c;
+  int c;
 
   while ((c = getopt(argc, argv, "hvsb:d:e:o:S:")) != -1) {
     switch (c) {
@@ -174,7 +176,7 @@ int main(int argc, char* argv[]) {
 
     stats.col(f) = mean;
 
-    if (mean <= threshold) {
+    if (!stats_only && mean <= threshold) {
       if (image.channels() != nchan) {
         if (verbose)
           fprintf(stderr, "repairing channel mismatch: %d != %d\n",


### PR DESCRIPTION
This depends on the previous PR to add getopt. Now that I have getopt, it's easy to add extra flags to do useful things, like filtering improperly sized images to avoid opencv assertion failures.