### PR TITLE
Initialize num and exposureAdjustment values to 0

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -2100,7 +2100,7 @@ const char *locale = DEFAULT_LOCALE;
                          displayDebugText(textBuffer, 2);
 
 			 std::string why;	// Why did we adjust the exposure?  For debugging
-			 int num=0;
+			 int num = 0;
                          if (mean >= 254) {
                              newExposure = currentExposure * 0.4;
                              tempMaxExposure = currentExposure - roundToMe;

--- a/capture.cpp
+++ b/capture.cpp
@@ -2064,7 +2064,7 @@ const char *locale = DEFAULT_LOCALE;
                         // We asked but got a useless reply.
                         // Values below the default make the image darker; above make it brighter.
 
-                        float exposureAdjustment, numMultiples;
+                        float exposureAdjustment = 0.0, numMultiples;
 
                         // Adjustments of DEFAULT_BRIGHTNESS up or down make the image this much darker/lighter.
                         // Don't want the max brightness to give pure white.
@@ -2100,7 +2100,7 @@ const char *locale = DEFAULT_LOCALE;
                          displayDebugText(textBuffer, 2);
 
 			 std::string why;	// Why did we adjust the exposure?  For debugging
-			 int num;
+			 int num=0;
                          if (mean >= 254) {
                              newExposure = currentExposure * 0.4;
                              tempMaxExposure = currentExposure - roundToMe;


### PR DESCRIPTION
During compile a warning is issued for a possibly uninitialized variable.  This is due to the declaration of these variables having no value, and no default 'else' is present to set them should none of the conditional tests match.

Added 0 and 0.0 values to the declaration of these variables to remove the compile warning.


```
capture.cpp: In function ‘int main(int, char**)’:
capture.cpp:2187:33: warning: ‘num’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                          sprintf(textBuffer, "  > !!! Retrying @ %'ld us because '%s (%d)'\n", currentExposure, why.c_str(), num);
                          ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
capture.cpp:2094:48: warning: ‘exposureAdjustment’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                         maxAcceptableHistogram *= exposureAdjustment;
                         ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
```