### PR TITLE
Modified OpenCV calls to use OpenCV4 compatible format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 
 ifeq ($(platform), armv7l)
 # Some distributions may need to use opencv4 and -DOPENCV_C_HEADERS as is done for x86_64
-OPENCV = $(shell pkg-config --cflags opencv) $(shell pkg-config --libs opencv)
+OPENCV = $(shell pkg-config --cflags opencv4) $(shell pkg-config --libs opencv4)
 CC = arm-linux-gnueabihf-g++
 AR= arm-linux-gnueabihf-ar
 CFLAGS += -march=armv7 -mthumb

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,54 @@
 platform = $(shell uname -m)
 
-USB=$(shell pkg-config --cflags libusb-1.0) $(shell pkg-config --libs libusb-1.0)
+USB=$(shell pkg-config --cflags --libs libusb-1.0)
+ifeq (,$(USB))
+  $(warning Did not find USB Libraries, you may need to install libusb-dev.)
+  $(error Missing dependencies)
+endif
+
 DEFS = -D_LIN -D_DEBUG -DGLIBC_20
 CFLAGS = -Wall -Wno-psabi -g -O2 -lpthread
+OPENCV = $(shell pkg-config --exists opencv && pkg-config --cflags --libs opencv || pkg-config --exists opencv4 && pkg-config --cflags --libs opencv4)
+
+ifeq (,$(OPENCV))
+  $(warning Did not find any OpenCV Libraries, you may need to install libopencv-dev.)
+  $(error Missing dependencies)
+endif
 
 ifeq ($(platform), armv6l)
-OPENCV = $(shell pkg-config --cflags opencv) $(shell pkg-config --libs opencv)
-CC = arm-linux-gnueabihf-g++
-AR= arm-linux-gnueabihf-ar
-CFLAGS += -march=armv6
-CFLAGS += -lrt
-ZWOSDK = -Llib/armv6 -I./include
+  CC = arm-linux-gnueabihf-g++
+  AR= arm-linux-gnueabihf-ar
+  CFLAGS += -march=armv6
+  CFLAGS += -lrt
+  ZWOSDK = -Llib/armv6 -I./include
 endif
 
 ifeq ($(platform), armv7l)
-# Some distributions may need to use opencv4 and -DOPENCV_C_HEADERS as is done for x86_64
-OPENCV = $(shell pkg-config --cflags opencv) $(shell pkg-config --libs opencv)
-ifeq ($(OPENCV), " ")
-OPENCV = $(shell pkg-config --cflags opencv4) $(shell pkg-config --libs opencv4)
-DEFS += -DOPENCV_C_HEADERS
-endif
-CC = arm-linux-gnueabihf-g++
-AR= arm-linux-gnueabihf-ar
-CFLAGS += -march=armv7 -mthumb
-ZWOSDK = -Llib/armv7 -I./include
+  # Some distributions may need to use opencv4 and -DOPENCV_C_HEADERS as is done for x86_64
+  CC = arm-linux-gnueabihf-g++
+  AR= arm-linux-gnueabihf-ar
+  CFLAGS += -march=armv7 -mthumb
+  ZWOSDK = -Llib/armv7 -I./include
 endif
 
 #Ubuntu has opencv4, not opencv2
 ifeq ($(platform), x86_64)
-OPENCV = $(shell pkg-config --cflags opencv4) $(shell pkg-config --libs opencv4)
-CC = g++
-AR= ar
-DEFS += -DOPENCV_C_HEADERS
-ZWOSDK = -Llib/x64 -I./include
+  CC = g++
+  AR= ar
+  DEFS += -DOPENCV_C_HEADERS
+  ZWOSDK = -Llib/x64 -I./include
 endif
 
 ifeq ($(platform), i386) # FIXME: is this correct?
-OPENCV = $(shell pkg-config --cflags opencv4) $(shell pkg-config --libs opencv4)
-CC = g++
-AR= ar
-DEFS += -DOPENCV_C_HEADERS
-ZWOSDK = -Llib/x86 -I./include
+  CC = g++
+  AR= ar
+  DEFS += -DOPENCV_C_HEADERS
+  ZWOSDK = -Llib/x86 -I./include
+endif
+
+ifeq (,$(CC))
+  $(warning Could not identify the proper compiler for your platform.)
+  $(error Unknown platform $(platform))
 endif
 
 CFLAGS += $(DEFS) $(ZWOSDK)

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ endif
 ifeq ($(platform), armv7l)
 # Some distributions may need to use opencv4 and -DOPENCV_C_HEADERS as is done for x86_64
 OPENCV = $(shell pkg-config --cflags opencv4) $(shell pkg-config --libs opencv4)
+DEFS += -DOPENCV_C_HEADERS
 CC = arm-linux-gnueabihf-g++
 AR= arm-linux-gnueabihf-ar
 CFLAGS += -march=armv7 -mthumb

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,11 @@ endif
 
 ifeq ($(platform), armv7l)
 # Some distributions may need to use opencv4 and -DOPENCV_C_HEADERS as is done for x86_64
+OPENCV = $(shell pkg-config --cflags opencv) $(shell pkg-config --libs opencv)
+ifeq ($(OPENCV), " ")
 OPENCV = $(shell pkg-config --cflags opencv4) $(shell pkg-config --libs opencv4)
 DEFS += -DOPENCV_C_HEADERS
+endif
 CC = arm-linux-gnueabihf-g++
 AR= arm-linux-gnueabihf-ar
 CFLAGS += -march=armv7 -mthumb

--- a/autostart/allsky.service
+++ b/autostart/allsky.service
@@ -5,8 +5,6 @@ After=multi-user.target
 [Service]
 User=pi
 ExecStart=/home/pi/allsky/allsky.sh
-StandardOutput=syslog
-StandardError=syslog
 SyslogFacility=local5
 Restart=always
 RestartSec=5

--- a/capture.cpp
+++ b/capture.cpp
@@ -5,9 +5,10 @@
 #include <opencv2/imgcodecs/legacy/constants_c.h>
 #endif
 
-#include <opencv2/core/core.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/viz.hpp>
 #include "include/ASICamera2.h"
 #include <sys/time.h>
 #include <sys/stat.h>
@@ -177,15 +178,15 @@ void cvText(cv::Mat &img, const char *text, int x, int y, double fontsize, int l
     {
         unsigned long fontcolor16 = createRGB(fontcolor[2], fontcolor[1], fontcolor[0]);
         if (outlinefont)
-            cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(0,0,0), linewidth+4, linetype);
-        cv::putText(img, text, cvPoint(x, y), fontname, fontsize, fontcolor16, linewidth, linetype);
+            cv::putText(img, text, cv::Point(x, y), fontname, fontsize, cv::Scalar(0,0,0), linewidth+4, linetype);
+        cv::putText(img, text, cv::Point(x, y), fontname, fontsize, fontcolor16, linewidth, linetype);
     }
     else
     {
         if (outlinefont)
-            cv::putText(img, text, cvPoint(x, y), fontname, fontsize, cvScalar(0,0,0, 255), linewidth+4, linetype);
-        cv::putText(img, text, cvPoint(x, y), fontname, fontsize,
-                    cvScalar(fontcolor[0], fontcolor[1], fontcolor[2], 255), linewidth, linetype);
+            cv::putText(img, text, cv::Point(x, y), fontname, fontsize, cv::Scalar(0,0,0, 255), linewidth+4, linetype);
+        cv::putText(img, text, cv::Point(x, y), fontname, fontsize,
+                    cv::Scalar(fontcolor[0], fontcolor[1], fontcolor[2], 255), linewidth, linetype);
     }
 }
 
@@ -213,7 +214,7 @@ char *getTime(char const *tf)
 
 double timeDiff(int64 start, int64 end)
 {
-	double frequency = cvGetTickFrequency();
+	double frequency = cv::getTickFrequency();
 	return (double)(end - start) / frequency;	// in Microseconds
 }
 
@@ -236,14 +237,14 @@ std::string exec(const char *cmd)
 
 void *Display(void *params)
 {
-    cv::Mat *pImg = (cv::Mat *)params;
-    cvNamedWindow("video", 1);
+    //cv::Mat *pImg = (cv::Mat *)params;
+    cv::namedWindow("video", 1);
     while (bDisplay)
     {
-        cvShowImage("video", pImg);
-        cvWaitKey(100);
+        //cv::ShowImage("video", pImg);
+        cv::waitKey(100);
     }
-    cvDestroyWindow("video");
+    cv::destroyWindow("video");
     printf("Display thread over\n");
     return (void *)0;
 }
@@ -788,9 +789,9 @@ int main(int argc, char *argv[])
     pthread_cond_init(&cond_SatrtSave, 0);
 
     int fontname[] = {
-        CV_FONT_HERSHEY_SIMPLEX,        CV_FONT_HERSHEY_PLAIN,         CV_FONT_HERSHEY_DUPLEX,
-        CV_FONT_HERSHEY_COMPLEX,        CV_FONT_HERSHEY_TRIPLEX,       CV_FONT_HERSHEY_COMPLEX_SMALL,
-        CV_FONT_HERSHEY_SCRIPT_SIMPLEX, CV_FONT_HERSHEY_SCRIPT_COMPLEX };
+        cv::FONT_HERSHEY_SIMPLEX,        cv::FONT_HERSHEY_PLAIN,         cv::FONT_HERSHEY_DUPLEX,
+        cv::FONT_HERSHEY_COMPLEX,        cv::FONT_HERSHEY_TRIPLEX,       cv::FONT_HERSHEY_COMPLEX_SMALL,
+        cv::FONT_HERSHEY_SCRIPT_SIMPLEX, cv::FONT_HERSHEY_SCRIPT_COMPLEX };
     char const *fontnames[] = {		// Character representation of names for clarity:
         "SIMPLEX",                      "PLAIN",                       "DUPEX",
         "COMPLEX",                      "TRIPLEX",                     "COMPLEX_SMALL",
@@ -838,7 +839,7 @@ const char *locale = DEFAULT_LOCALE;
     int outlinefont            = DEFAULT_OUTLINEFONT;
     int fontcolor[3]           = { 255, 0, 0 };
     int smallFontcolor[3]      = { 0, 0, 255 };
-    int linetype[3]            = { CV_AA, 8, 4 };
+    int linetype[3]            = { cv::LINE_AA, 8, 4 };
 #define DEFAULT_LINENUMBER       0
     int linenumber             = DEFAULT_LINENUMBER;
 
@@ -1410,7 +1411,7 @@ const char *locale = DEFAULT_LOCALE;
 	}
 
         imagetype = "jpg";
-        compression_parameters.push_back(CV_IMWRITE_JPEG_QUALITY);
+        compression_parameters.push_back(cv::IMWRITE_JPEG_QUALITY);
         if (quality == NOT_SET)
         {
             quality = 95;
@@ -1422,7 +1423,7 @@ const char *locale = DEFAULT_LOCALE;
     else if (strcasecmp(ext + 1, "png") == 0)
     {
         imagetype = "png";
-        compression_parameters.push_back(CV_IMWRITE_PNG_COMPRESSION);
+        compression_parameters.push_back(cv::IMWRITE_PNG_COMPRESSION);
         if (quality == NOT_SET)
         {
             quality = 3;
@@ -1934,15 +1935,15 @@ const char *locale = DEFAULT_LOCALE;
 
         if (Image_type == ASI_IMG_RAW16)
         {
-            pRgb.create(cvSize(width, height), CV_16UC1);
+            pRgb.create(cv::Size(width, height), CV_16UC1);
         }
         else if (Image_type == ASI_IMG_RGB24)
         {
-            pRgb.create(cvSize(width, height), CV_8UC3);
+            pRgb.create(cv::Size(width, height), CV_8UC3);
         }
         else // RAW8 and Y8
         {
-            pRgb.create(cvSize(width, height), CV_8UC1);
+            pRgb.create(cv::Size(width, height), CV_8UC1);
         }
 
         asiRetCode = ASISetROIFormat(CamNum, width, height, currentBin, (ASI_IMG_TYPE)Image_type);
@@ -2315,7 +2316,7 @@ const char *locale = DEFAULT_LOCALE;
                     {
                         // Draw a rectangle where the histogram box is.
 
-                        int lt = CV_AA, thickness = 2;
+                        int lt = cv::LINE_AA, thickness = 2;
 			cv::Point from1, to1, from2, to2;
                         int X1 = (width * histogramBoxPercentFromLeft) - (histogramBoxSizeX / 2);
                         int X2 = X1 + histogramBoxSizeX;
@@ -2327,36 +2328,36 @@ const char *locale = DEFAULT_LOCALE;
                         // cv::line takes care of bytes per pixel.
 
                         // top lines
-			from1 = cvPoint(X1, Y1);
-			to1 = cvPoint(X2, Y1);
-                        from2 = cvPoint(X1, Y1+thickness);
-                        to2 = cvPoint(X2, Y1+thickness);
-                        cv::line(pRgb, from1, to1, cvScalar(0,0,0), thickness, lt);
-                        cv::line(pRgb, from2, to2, cvScalar(255,255,255), thickness, lt);
+			from1 = cv::Point(X1, Y1);
+			to1 = cv::Point(X2, Y1);
+                        from2 = cv::Point(X1, Y1+thickness);
+                        to2 = cv::Point(X2, Y1+thickness);
+                        cv::line(pRgb, from1, to1, cv::Scalar(0,0,0), thickness, lt);
+                        cv::line(pRgb, from2, to2, cv::Scalar(255,255,255), thickness, lt);
 
                         // right lines
-			from1 = cvPoint(X2, Y1);
-			to1 = cvPoint(X2, Y2);
-                        from2 = cvPoint(X2-thickness, Y1+thickness);
-                        to2 = cvPoint(X2-thickness, Y2-thickness);
-                        cv::line(pRgb, from1, to1, cvScalar(0,0,0), thickness, lt);
-                        cv::line(pRgb, from2, to2, cvScalar(255,255,255), thickness, lt);
+			from1 = cv::Point(X2, Y1);
+			to1 = cv::Point(X2, Y2);
+                        from2 = cv::Point(X2-thickness, Y1+thickness);
+                        to2 = cv::Point(X2-thickness, Y2-thickness);
+                        cv::line(pRgb, from1, to1, cv::Scalar(0,0,0), thickness, lt);
+                        cv::line(pRgb, from2, to2, cv::Scalar(255,255,255), thickness, lt);
 
                         // bottom lines
-			from1 = cvPoint(X1, Y2);
-			to1 = cvPoint(X2, Y2);
-                        from2 = cvPoint(X1, Y2-thickness);
-                        to2 = cvPoint(X2, Y2-thickness);
-                        cv::line(pRgb, from1, to1, cvScalar(0,0,0), thickness, lt);
-                        cv::line(pRgb, from2, to2, cvScalar(255,255,255), thickness, lt);
+			from1 = cv::Point(X1, Y2);
+			to1 = cv::Point(X2, Y2);
+                        from2 = cv::Point(X1, Y2-thickness);
+                        to2 = cv::Point(X2, Y2-thickness);
+                        cv::line(pRgb, from1, to1, cv::Scalar(0,0,0), thickness, lt);
+                        cv::line(pRgb, from2, to2, cv::Scalar(255,255,255), thickness, lt);
 
                         // left lines
-			from1 = cvPoint(X1, Y1);
-			to1 = cvPoint(X1, Y2);
-                        from2 = cvPoint(X1+thickness, Y1+thickness);
-                        to2 = cvPoint(X1+thickness, Y2-thickness);
-                        cv::line(pRgb, from1, to1, cvScalar(0,0,0), thickness, lt);
-                        cv::line(pRgb, from2, to2, cvScalar(255,255,255), thickness, lt);
+			from1 = cv::Point(X1, Y1);
+			to1 = cv::Point(X1, Y2);
+                        from2 = cv::Point(X1+thickness, Y1+thickness);
+                        to2 = cv::Point(X1+thickness, Y2-thickness);
+                        cv::line(pRgb, from1, to1, cv::Scalar(0,0,0), thickness, lt);
+                        cv::line(pRgb, from2, to2, cv::Scalar(255,255,255), thickness, lt);
                     }
 #endif
                     /**
@@ -2445,9 +2446,9 @@ const char *locale = DEFAULT_LOCALE;
 
                     pthread_mutex_lock(&mtx_SaveImg);
                     // Display the time it took to save an image, for debugging.
-                    int64 st = cvGetTickCount();
+                    int64 st = cv::getTickCount();
                     pthread_cond_signal(&cond_SatrtSave);
-                    int64 et = cvGetTickCount();
+                    int64 et = cv::getTickCount();
                     pthread_mutex_unlock(&mtx_SaveImg);
 
                     sprintf(textBuffer, "  (%.0f us)\n", timeDiff(st, et));

--- a/capture.cpp
+++ b/capture.cpp
@@ -2100,7 +2100,7 @@ const char *locale = DEFAULT_LOCALE;
                          displayDebugText(textBuffer, 2);
 
 			 std::string why;	// Why did we adjust the exposure?  For debugging
-			 int num=0;
+			 int num = 0;
                          if (mean >= 254) {
                              newExposure = currentExposure * 0.4;
                              tempMaxExposure = currentExposure - roundToMe;

--- a/capture.cpp
+++ b/capture.cpp
@@ -237,11 +237,17 @@ std::string exec(const char *cmd)
 
 void *Display(void *params)
 {
-    //cv::Mat *pImg = (cv::Mat *)params;
+    cv::Mat *para = (cv::Mat *)params;
+    int w=para->cols;
+    int h=para->rows;
+    
+    cv::Mat pImg(h,w,(int)para->type(),(uchar *)para->data);
     cv::namedWindow("video", 1);
     while (bDisplay)
     {
-        //cv::ShowImage("video", pImg);
+        // With this in, a compile error occurs:
+	// no known conversion for argument 2 from ‘cv::Mat*’ to ‘cv::InputArray’
+        cv::imshow("video", pImg);
         cv::waitKey(100);
     }
     cv::destroyWindow("video");

--- a/capture.cpp
+++ b/capture.cpp
@@ -2064,7 +2064,7 @@ const char *locale = DEFAULT_LOCALE;
                         // We asked but got a useless reply.
                         // Values below the default make the image darker; above make it brighter.
 
-                        float exposureAdjustment, numMultiples;
+                        float exposureAdjustment = 0.0, numMultiples;
 
                         // Adjustments of DEFAULT_BRIGHTNESS up or down make the image this much darker/lighter.
                         // Don't want the max brightness to give pure white.
@@ -2100,7 +2100,7 @@ const char *locale = DEFAULT_LOCALE;
                          displayDebugText(textBuffer, 2);
 
 			 std::string why;	// Why did we adjust the exposure?  For debugging
-			 int num;
+			 int num=0;
                          if (mean >= 254) {
                              newExposure = currentExposure * 0.4;
                              tempMaxExposure = currentExposure - roundToMe;

--- a/keogram.cpp
+++ b/keogram.cpp
@@ -19,8 +19,8 @@
 #include <opencv2/imgcodecs/legacy/constants_c.h>
 #endif
 
-#include <opencv2/highgui/highgui.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgproc.hpp>
 #include <opencv2/opencv.hpp>
 
 #define KNRM "\x1B[0m"
@@ -199,9 +199,9 @@ int main(int argc, char *argv[])
     globfree(&files);
 
     std::vector<int> compression_params;
-    compression_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+    compression_params.push_back(cv::IMWRITE_PNG_COMPRESSION);
     compression_params.push_back(9);
-    compression_params.push_back(CV_IMWRITE_JPEG_QUALITY);
+    compression_params.push_back(cv::IMWRITE_JPEG_QUALITY);
     compression_params.push_back(95);
 
     cv::imwrite(outputfile, accumulated, compression_params);

--- a/startrails.cpp
+++ b/startrails.cpp
@@ -17,8 +17,8 @@
 #include <opencv2/imgcodecs/legacy/constants_c.h>
 #endif
 
-#include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/highgui.hpp>
 
 #define KNRM "\x1B[0m"
 #define KRED "\x1B[31m"
@@ -140,9 +140,9 @@ int main(int argc, char *argv[])
     globfree(&files);
 
     std::vector<int> compression_params;
-    compression_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+    compression_params.push_back(cv::IMWRITE_PNG_COMPRESSION);
     compression_params.push_back(9);
-    compression_params.push_back(CV_IMWRITE_JPEG_QUALITY);
+    compression_params.push_back(cv::IMWRITE_JPEG_QUALITY);
     compression_params.push_back(95);
 
     cv::imwrite(outputfile, accumulated, compression_params);


### PR DESCRIPTION
Updated all cvFunction to cv::function, etc.. format to be compatible with OpenCV4.  I had quite a bit of issue getting the Display() function to compile, but finally got something workable -- although, I've not tested the Display capability.

Would love for someone to test the Display code prior to merge.  Otherwise, the rest of the code should compile fine on both Raspberry Pi OS based on Debian Buster with OpenCV 3.2.0, as well as Debian Bullseye with OpenCV 4.5.1.