### PR TITLE
Fixed missing sudo on sed /etc/xdg/lxsession/LXDE-pi/autostart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ sudo udevadm control -R
 echo -en '\n'
 
 echo -en "${GREEN}* Autostart script\n${NC}"
-sed -i '/allsky.sh/d' /etc/xdg/lxsession/LXDE-pi/autostart
+[ -e /etc/xdg/lxsession/LXDE-pi/autostart ] && sudo sed -i '/allsky.sh/d' /etc/xdg/lxsession/LXDE-pi/autostart
 sed -i "s|User=pi|User=$USER|g" autostart/allsky.service
 sed -i "s|/home/pi/allsky|$PWD|g" autostart/allsky.service
 sudo install -D -m 0644 autostart/allsky.service /etc/systemd/system/


### PR DESCRIPTION
Resolves #514 

There was one missing sudo, but it wasn't the full contributor to all the errors.  Looks like the local git repo was owned by root, but the compile / install was tried as regular user.  Regular user `install.sh` will work, but the git repo must be owned by that user.
