### PR TITLE
copy_notification_image.sh: fix IMG_DIR bug

### DIFF
--- a/scripts/copy_notification_image.sh
+++ b/scripts/copy_notification_image.sh
@@ -2,22 +2,21 @@
 
 ME="$(basename "${BASH_ARGV0}")"
 
-NOTIFICATIONFILE="$1"	# filename, minus the extension, since the extension may vary
-if [ "$1" = "" ] ; then
-	echo "*** ${ME}: ERROR: no file specified" >&2
-	exit 1
-fi
-
 source "${ALLSKY_HOME}/variables.sh"
 source "${ALLSKY_CONFIG}/config.sh"
 source "${ALLSKY_SCRIPTS}/filename.sh"
 source "${ALLSKY_SCRIPTS}/ftp-settings.sh"
 
+NOTIFICATIONFILE="$1"	# filename, minus the extension, since the extension may vary
+if [ "$1" = "" ] ; then
+	echo "${RED}*** ${ME}: ERROR: no file specified.${NC}" >&2
+	exit 1
+fi
 cd "${ALLSKY_HOME}"
 
 NOTIFICATIONFILE="${ALLSKY_NOTIFICATION_IMAGES}/${NOTIFICATIONFILE}.${EXTENSION}"
 if [ ! -e "${NOTIFICATIONFILE}" ] ; then
-	echo "*** ${ME}: ERROR: File '${NOTIFICATIONFILE}' does not exist or is empty!" >&2
+	echo "${RED}*** ${ME}: ERROR: File '${NOTIFICATIONFILE}' does not exist or is empty!${NC}" >&2
 	exit 2
 fi
 
@@ -28,9 +27,8 @@ cp "${NOTIFICATIONFILE}" "${IMAGE_TO_USE}"
 # Resize the image if required
 if [ "${IMG_RESIZE}" = "true" ]; then
         convert "${IMAGE_TO_USE}" -resize "${IMG_WIDTH}x${IMG_HEIGHT}" "${IMAGE_TO_USE}"
-	RET=$?
-	if [ ${RET} -ne 0 ] ; then
-		echo "*** ${ME}: ERROR: IMG_RESIZE failed with RET=${RET}"
+	if [ $? -ne 0 ] ; then
+		echo "${RED}*** ${ME}: ERROR: IMG_RESIZE failed${NC}"
 		exit 3
 	fi
 fi
@@ -40,14 +38,13 @@ fi
 # Don't save in main image directory because we don't want the notification image in timelapses.
 # If at nighttime, save them in (possibly) yesterday's directory.
 # If during day, save in today's directory.
-if [ "${CAPTURE_24HR}" = "true" ] ; then
+if [ "${DAYTIME_SAVE}" = "true" -o "${CAPTURE_24HR}" = "true" ] ; then
 	IMAGES_DIR="${ALLSKY_IMAGES}/$(date +'%Y%m%d')"
 	THUMB="${IMAGES_DIR}/thumbnails/${FILENAME}-$(date +'%Y%m%d%H%M%S').${EXTENSION}"
 
 	convert "${IMAGE_TO_USE}" -resize "${THUMBNAIL_SIZE_X}x${THUMBNAIL_SIZE_Y}" "${THUMB}"
-	RET=$?
-	if [ ${RET} -ne 0 ] ; then
-		echo "*** ${ME}: WARNING: THUMBNAIL resize failed with RET=${RET}; continuing."
+	if [ $? -ne 0 ] ; then
+		echo "${YELLOW}*** ${ME}: WARNING: THUMBNAIL resize failed; continuing.${NC}"
     	fi
 fi
 
@@ -61,9 +58,8 @@ if [ "${UPLOAD_IMG}" = "true" ] ; then
 	if [ "${RESIZE_UPLOADS}" = "true" ]; then
 		# Create a smaller version for upload
 		convert "${IMAGE_TO_USE}" -resize "${RESIZE_UPLOADS_SIZE}" -gravity East -chop 2x0 "${IMAGE_TO_USE}"
-		RET=$?
-		if [ ${RET} -ne 0 ] ; then
-			echo "*** ${ME}: ERROR: RESIZE_UPLOADS failed with RET=${RET}"
+		if [ $? -ne 0 ] ; then
+			echo "${RED}*** ${ME}: ERROR: RESIZE_UPLOADS failed${NC}"
 			exit 4
     		fi
 	fi
@@ -72,6 +68,7 @@ if [ "${UPLOAD_IMG}" = "true" ] ; then
 	# in the message since it's more descriptive.
 	echo -e "${ME}: Uploading $(basename "${NOTIFICATIONFILE}")\n"
 	# NI == Notification Image
-	"${ALLSKY_SCRIPTS}/upload.sh" --silent "${IMAGE_TO_USE}" "${IMG_DIR}" "${FULL_FILENAME}" "NI"
+	"${ALLSKY_SCRIPTS}/upload.sh" --silent "${IMAGE_TO_USE}" "${IMGDIR}" "${FULL_FILENAME}" "NI"
+	exit $?
 fi
 exit 0


### PR DESCRIPTION
This causes all Notification Image uploads to fail, leaving an "NI-*" file on the remote server.