### PR TITLE
Fixes 'jq' try to read settings_auto.json warning in logs

### DIFF
--- a/allsky.sh
+++ b/allsky.sh
@@ -63,7 +63,10 @@ fi
 
 # CAMERA AUTOSELECT
 # exit if no camera found at all
+WAS_AUTO=0
+
 if [[ $CAMERA == "auto" ]]; then
+  WAS_AUTO=1
   echo "Trying to automatically choose between ZWO and RPI camera"
   if [[ $ZWOIsPresent -eq 0 && $RPiHQIsPresent -eq 0 ]]; then
           echo "None of RPI or ZWO Cameras were found. Exiting." >&2
@@ -85,6 +88,10 @@ echo "CAMERA: ${CAMERA}"
 echo "CAMERA_SETTINGS: ${CAMERA_SETTINGS}"
 # save auto camera selection for the current session, will be read in "$ALLSKY_HOME/config.sh" file
 echo "export CAMERA=$CAMERA" > "$ALLSKY_HOME/autocam.sh"
+
+if [ $WAS_AUTO -eq 1 ]; then  # Get the proper debug level since earlier config.sh run couldn't.
+	ALLSKY_DEBUG_LEVEL=$(jq -r '.debuglevel' "${CAMERA_SETTINGS}")
+fi
 
 # this must be called after camera autoselect
 source $ALLSKY_HOME/scripts/filename.sh

--- a/config_repo/config.sh.repo
+++ b/config_repo/config.sh.repo
@@ -117,12 +117,12 @@ IMG_PREFIX="liveview-"
 # Path to the camera settings (exposure, gain, delay, overlay, etc)
 CAMERA_SETTINGS_DIR="$ALLSKY_HOME"
 
-if [[ $CAMERA -eq "auto" ]]; then
+if [[ $CAMERA == "auto" ]]; then
   # restore currently saved autodiscovered camera mode if any
   source "$ALLSKY_HOME/autocam.sh"
 fi
 
-if [[ $CAMERA -ne "auto" ]]; then
+if [[ $CAMERA != "auto" ]]; then
   CAMERA_SETTINGS="$CAMERA_SETTINGS_DIR/settings_$CAMERA.json"
  
   # So scripts can conditionally ouput messages; DO NOT CHANGE NEXT LINES.

--- a/config_repo/config.sh.repo
+++ b/config_repo/config.sh.repo
@@ -121,8 +121,12 @@ if [[ $CAMERA -eq "auto" ]]; then
   # restore currently saved autodiscovered camera mode if any
   source "$ALLSKY_HOME/autocam.sh"
 fi
-CAMERA_SETTINGS="$CAMERA_SETTINGS_DIR/settings_$CAMERA.json"
 
-# So scripts can conditionally ouput messages; DO NOT CHANGE NEXT LINES.
-ALLSKY_DEBUG_LEVEL=$(jq -r '.debuglevel' "${CAMERA_SETTINGS}")
+if [[ $CAMERA -ne "auto" ]]; then
+  CAMERA_SETTINGS="$CAMERA_SETTINGS_DIR/settings_$CAMERA.json"
+ 
+  # So scripts can conditionally ouput messages; DO NOT CHANGE NEXT LINES.
+  ALLSKY_DEBUG_LEVEL=$(jq -r '.debuglevel' "${CAMERA_SETTINGS}")
+fi
+
 ALLSKY_DEBUG_LEVEL=${ALLSKY_DEBUG_LEVEL:-0}


### PR DESCRIPTION
Fixed in two steps:
- If `CAMERA` is still set to `auto` after reading `autocam.sh` from `config.sh`, don't try to read the camera settings, instead set default debug level 0.
- In `allsky.sh`, if auto camera detection was selected, and we detect a camera, re-read debug level from the proper camera settings file.