### PR TITLE
Renamed MP4DIR to VIDEOS_DIR to match endOfNight.sh expectation

### DIFF
--- a/scripts/ftp-settings.sh.repo
+++ b/scripts/ftp-settings.sh.repo
@@ -6,7 +6,7 @@ USER='username'
 PASSWORD='password'
 HOST='example.com'
 IMGDIR='/allsky/'
-MP4DIR='/allsky/videos/'
+VIDEOS_DIR='/allsky/videos/'
 KEOGRAM_DIR='/allsky/keograms/'
 STARTRAILS_DIR='/allsky/startrails/'
 


### PR DESCRIPTION
`endOfNight.sh` was using a variable `VIDEOS_DIR` which was not defined.  Updated `ftp-settings.sh.repo` to match the expectations of `endOfNight.sh`.

Resolves #552 