### PR TITLE
tune output of diagnostic messages.

### DIFF
--- a/src/startrails.cpp
+++ b/src/startrails.cpp
@@ -130,7 +130,7 @@ int main(int argc, char* argv[]) {
   parse_args(argc, argv, &config);
 
   if (config.verbose < 1)
-    if (e = getenv("ALLSKY_DEBUG_LEVEL"))
+    if ((e = getenv("ALLSKY_DEBUG_LEVEL")))
       if ((i = atoi(e)) > 0)
         config.verbose = i;
 


### PR DESCRIPTION
In the spirit of unix, "no news" is good news. Recoverable errors are not printed because there's no action required from the user.

If a single `-v` is given, then more diagnostics are emitted, including recoverable error (file name, error type, resolution).

If multiple `-v` are given, every file is printed as it is processed.

Finally, if no `-v` are given, then the value of the `ALLSKY_DEBUG_LEVEL` environment variable is used.

related to #539 