### PR TITLE
postData.sh: fix DAYTIME_CAPTURE bug

### DIFF
--- a/scripts/postData.sh
+++ b/scripts/postData.sh
@@ -13,7 +13,7 @@ longitude=$(jq -r '.longitude' "${CAMERA_SETTINGS}")
 timezone=$(date "+%z")
 streamDaytime=false
 
-if [[ ${DAYTIME} == "true" || ${DAYTIME} == "1" ]] ; then
+if [[ ${DAYTIME_CAPTURE} == "true" || ${DAYTIME} == "1" ]] ; then	# xxxx DAYTIME is old name
 	streamDaytime="true"
 fi
 


### PR DESCRIPTION
DAYTIME is old name, DAYTIME_CAPTURE is new name (and it uses true/false instead of 0/1).
Until the new config.sh is fully deployed, check for both variables.