### PR TITLE
Add .PHONY entries, add *.cpp dependencies for binary targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ endif
 deps:
 	@make -C src $@
 
+.PHONY : deps
+
 install:
 ifneq ($(ROOTCHECK), 0)
 	@echo This must be run with root permissions.
@@ -54,3 +56,4 @@ else
 	  echo ""; \
 	fi
 endif
+.PHONY : install

--- a/config_repo/Makefile
+++ b/config_repo/Makefile
@@ -57,11 +57,14 @@ createDirs:
 	@if [ ! -e $(DESTDIR)$(sysconfdir)/systemd/system ]; then mkdir -p $(DESTDIR)$(sysconfdir)/systemd/system; fi
 	@if [ ! -e $(DESTDIR)$(sysconfdir)/udev/rules.d ]; then mkdir -p $(DESTDIR)$(sysconfdir)/udev/rules.d; fi
 
+.PHONY : createDirs
+
 $(CONFIGFILES):
 	@if [ ! -e $(DESTDIR)$(sysconfdir)/allsky/$@ ]; then \
 	  echo `date +%F\ %R:%S` Copying default $@; \
 	  install -m 0644 $@.repo $(DESTDIR)$(sysconfdir)/allsky/$@; \
 	fi
+.PHONY : $(CONFIGFILES)
 
 install: createDirs $(CONFIGFILES)
 	@echo `date +%F\ %R:%S` Setting up udev rules...
@@ -80,15 +83,20 @@ remove_configs:
 	@echo `date +%F\ %R:%S` Removing config path and files ../config
 	@rm -rf ../config
 
+.PHONY : remove_configs
+
 createDirs:
 	@echo `date +%F\ %R:%S` Creating directory structures...
 	@if [ ! -e ../config ]; then mkdir -p ../config; chown $(SUDO_USER):$(SUDO_USER) ../config; fi
+
+.PHONY : createDirs
 
 $(CONFIGFILES):
 	@if [ ! -e ../config/$@ ]; then \
 	  echo `date +%F\ %R:%S` Copying default $@; \
 	  install -m 0644 -o $(SUDO_USER) -g $(SUDO_USER) $@.repo ../config/$@; \
 	fi
+.PHONY : $(CONFIGFILES)
 
 install: createDirs $(CONFIGFILES)
 	@echo `date +%F\ %R:%S` Setting up udev rules...
@@ -108,5 +116,6 @@ install: createDirs $(CONFIGFILES)
 	@echo `date +%F\ %R:%S` Setting up home environment variable...
 	@echo "export ALLSKY_HOME=$(PDIR)" > $(DESTDIR)$(sysconfdir)/profile.d/allsky.sh
 	@echo `date +%F\ %R:%S` Copying default ftp-settings.sh
+.PHONY : install
 endif # Package build check
 endif # Root check

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,6 +41,8 @@ else
 	@apt update && apt -y install libopencv-dev libusb-dev libusb-1.0-0-dev ffmpeg gawk lftp jq imagemagick
 endif
 
+.PHONY : deps
+
 USB=$(shell pkg-config --cflags --libs libusb-1.0)
 ifeq (,$(USB))
   $(error Did not find USB Libraries, try 'make deps')
@@ -99,6 +101,7 @@ CFLAGS += $(DEFS) $(ZWOSDK)
 	@echo `date +%F\ %R:%S` nothing to do for $@
 
 all:capture capture_RPiHQ startrails keogram sunwait
+.PHONY : all
 
 sunwait:
 	@echo `date +%F\ %R:%S` Initializing sunwait submodule...
@@ -176,9 +179,10 @@ uninstall:
 	fi
 
 endif # sudo / root check
+.PHONY : install uninstall
 
 clean:
 	rm -f capture capture_RPiHQ startrails keogram *.o *.a
-
+.PHONY : clean
 
 endif # Correct directory structure check


### PR DESCRIPTION
This update helps normalize the Makefile(s) for better user experience.

Specifically:
- Targets that do not create a file with the name of the target are labeled .PHONY per Makefile spec
- Targets which do compile a source have that source listed as a dependency - this permits updates to the source to be noticed and re-compiled on the next `make ` call.

This *may* resolve `make deps` issue from #590