### PR TITLE
shut up some warnings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,7 @@ endif
 
 USB=$(shell pkg-config --exists libusb-1.0 && pkg-config --cflags --libs libusb-1.0)
 DEFS = -D_LIN -D_DEBUG -DGLIBC_20
-CFLAGS = -Wall -Wno-psabi -g -O2 -lpthread
+CFLAGS = -Wall -Wno-psabi -Wno-unused-result -g -O2 -lpthread
 OPENCV = $(shell pkg-config --exists opencv && pkg-config --cflags --libs opencv || (pkg-config --exists opencv4 && pkg-config --cflags --libs opencv4))
 
 ifeq ($(platform), armv6l)

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -568,8 +568,7 @@ void IntHandle(int i)
 void waitToFix(char const *msg)
 {
     printf("**********\n");
-    printf(msg);
-    printf("\n");
+    printf("%s\n", msg);
     printf("*** After fixing, ");
     if (tty)
         printf("restart allsky.sh.\n");

--- a/src/capture_RPiHQ.cpp
+++ b/src/capture_RPiHQ.cpp
@@ -163,8 +163,7 @@ void IntHandle(int i)
 void waitToFix(char const *msg)
 {
     printf("**********\n");
-    printf(msg);
-    printf("\n");
+    printf("%s\n", msg);
     printf("*** After fixing, ");
     if (tty)
         printf("restart allsky.sh.\n");


### PR DESCRIPTION
`capture.cpp:571:15: warning: format not a string literal and no format arguments [-Wformat-security]`
`capture.cpp:275:23: warning: ignoring return value of ‘int system(const char*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]`
