### PR TITLE
Multithreaded startrail processing.

### DIFF
--- a/src/startrails.cpp
+++ b/src/startrails.cpp
@@ -287,7 +287,7 @@ void usage_and_exit(int x) {
   std::cout << "-e | --extension <str> : filter images to just this extension"
             << std::endl;
   std::cout << "-m | --max-threads <int> : limit maximum number of processing "
-               "threads. (0 = nproc)"
+               "threads. (unspecified = use all cpus)"
             << std::endl;
   std::cout << "-n | --nice <int> : nice(2) level of processing threads (10)"
             << std::endl;


### PR DESCRIPTION
Inspired by @sebmueller. This splits up the input images into batches of work
more or less evenly divided across the number of processors.

Two new flags are added:
* -n / --nice to make the workers be nice. default = 10
* -m / --max-threads to control the number of worker threads. default = ncpus

Allows me to process a night of startrails on my workstation in under 3.5s.
On my pi3b+, it'll use between 350% - 395% CPU without making it feel slow

```
root@skycam:/home/allsky/src# time ./startrails -b 0.255 -d ../images/20210912/ -e jpg -o /tmp/junk.jpg -s 1280x960
Minimum: 0.0265446 maximum: 0.804403 mean: 0.143959 median: 0.137787

real	5m5.951s
user	11m22.243s
sys	1m5.347s

root@skycam:/home/allsky/src# time ./startrails -b 0.255 -d ../images/20210912/ -e jpg -o /tmp/junk2.jpg -s 1280x960 --max-threads 1
Minimum: 0.0265446 maximum: 0.804403 mean: 0.143959 median: 0.137787

real	12m8.758s
user	11m3.073s
sys	0m54.200s

root@skycam:/home/allsky/src# md5sum /tmp/junk*
686e577252e03c5ebf9d569f20acd1e6  /tmp/junk2.jpg
686e577252e03c5ebf9d569f20acd1e6  /tmp/junk.jpg
```

Fixes thomasjacquin/allsky#628