### PR TITLE
Gui install fix - Only replace 1st instance of `XX_ALLSKY_HOME_XX`

### DIFF
--- a/gui/install.sh
+++ b/gui/install.sh
@@ -22,6 +22,8 @@ modify_locations() {	# Some files have placeholders for certain locations.  Modi
 	echo -e "${GREEN}* Modifying locations in web files${NC}"
 	(
 		cd "${PORTAL_DIR}/includes"
+		# NOTE: Only want to replace the FIRST instance of XX_ALLSKY_HOME_XX in funciton.php
+		#       Otherwise, the edit check in functions.php will always fail.
 		sed -i "0,/XX_ALLSKY_HOME_XX/{s;XX_ALLSKY_HOME_XX;${ALLSKY_HOME};}" functions.php
 		sed -i "s;XX_ALLSKY_HOME_XX;${ALLSKY_HOME};" save_file.php
 		sed -i -e "s;XX_ALLSKY_SCRIPTS_XX;${ALLSKY_SCRIPTS};" \


### PR DESCRIPTION
Resolves #709 
Resolves #706 

In `functions.php` from allsky-portal, the `install.sh` script replaced every instance of `XX_ALLSKY_HOME_XX`, including the one which is tested against to ensure the value has been set -away- from `XX_ALLSKY_HOME_XX`.  This means that it will always evaluate as if the defined variable hasn't been modified, since the value will always be the same as the define.

This patch lets the modification only occur to the first instance of `XX_ALLSKY_HOME_XX`, and not the second -- preserving the intent of the conditional check.