### PR TITLE
Fixed extension check logic in startrails.cpp

### DIFF
--- a/src/startrails.cpp
+++ b/src/startrails.cpp
@@ -329,7 +329,7 @@ int main(int argc, char* argv[]) {
     std::transform(extcheck.begin(), extcheck.end(), extcheck.begin(),
                    [](unsigned char c) { return std::tolower(c); });
 
-    if (extcheck.rfind(".png") == string::npos ||
+    if (extcheck.rfind(".png") == string::npos &&
         extcheck.rfind(".jpg") == string::npos) {
       fprintf(stderr,
               KRED "Output file '%s' is missing extension (.jpg or .png)\n\n",


### PR DESCRIPTION
The logic for checking file extension is incorrectly using logical OR vs logical AND.

Thanks to @jpaana spotting this issue in PR #723 

`extcheck.rfind(".png") == string::npos`  string::npos is only returned if no match is found.  Thus, to check that neither png nor jpg is found, the logical operator must be AND.

resolve #728 