### PR TITLE
Keogram li

### DIFF
--- a/src/capture_RPiHQ.cpp
+++ b/src/capture_RPiHQ.cpp
@@ -939,6 +939,10 @@ int main(int argc, char *argv[])
 				preview = atoi(argv[++i]);
 			}
 */
+            else if (strcmp(argv[i], "-debuglevel") == 0)
+            {
+                debugLevel = atoi(argv[++i]);
+            }
 			else if (strcmp(argv[i], "-showTime") == 0 || strcmp(argv[i], "-time") == 0)
 			{
 				time = atoi(argv[++i]);
@@ -1077,6 +1081,7 @@ int main(int argc, char *argv[])
 	printf(" Longitude: %s\n", longitude);
 	printf(" Sun Elevation: %s\n", angle);
 	// printf(" Preview: %s\n", yesNo(preview));
+    printf(" Debug Level: %d\n", debugLevel);
 	printf(" Time: %s\n", yesNo(time));
 	printf(" Show Details: %s\n", yesNo(showDetails));
 	printf(" Darkframe: %s\n", yesNo(darkframe));

--- a/src/keogram.cpp
+++ b/src/keogram.cpp
@@ -407,7 +407,7 @@ void parse_args(int argc, char** argv, struct config_t* cf) {
         {"channel-info", no_argument, 0, 'c'},
         {0, 0, 0, 0}};
 
-    c = getopt_long(argc, argv, "d:e:o:r:s:C:L:N:S:T:Q:q:npvhxc", long_options,
+    c = getopt_long(argc, argv, "d:e:o:r:s:L:C:N:S:T:Q:q:npvhxc", long_options,
                     &option_index);
     if (c == -1)
       break;
@@ -452,20 +452,22 @@ void parse_args(int argc, char** argv, struct config_t* cf) {
         cf->verbose++;
         break;
       case 'C':
-        if (strchr(optarg, ' ')) {
+        // Problems with "255 255 255" -> optarg is only "255 !!!
+        // solved without spaces - ever worked with optargs ???   
+        if (strchr(optarg, ',')) {
           int r, g, b;
-          sscanf(optarg, "%d %d %d", &b, &g, &r);
+          sscanf(optarg, "%d,%d,%d", &b, &g, &r);
           cf->b = b & 0xff;
           cf->g = g & 0xff;
           cf->r = r & 0xff;
-          break;
+        } else {
+          if (optarg[0] == '#')  // skip '#' if input is like '#coffee'
+            optarg++;
+          sscanf(optarg, "%06x", &tmp);
+          cf->b = tmp & 0xff;
+          cf->g = (tmp >> 8) & 0xff;
+          cf->r = (tmp >> 16) & 0xff;
         }
-        if (optarg[0] == '#')  // skip '#' if input is like '#coffee'
-          optarg++;
-        sscanf(optarg, "%06x", &tmp);
-        cf->b = tmp & 0xff;
-        cf->g = (tmp >> 8) & 0xff;
-        cf->r = (tmp >> 16) & 0xff;
         break;
       case 'L':
         cf->lineWidth = atoi(optarg);

--- a/src/keogram.cpp
+++ b/src/keogram.cpp
@@ -50,6 +50,7 @@ struct config_t {
   double fontScale;
   double rotation_angle;
   double brightness_limit;
+  int fixed_channel_number;
 } config;
 
 std::mutex stdio_mutex;
@@ -73,7 +74,7 @@ void keogram_worker(int thread_num,
                     cv::Mat* acc,
                     cv::Mat* ann,
                     cv::Mat* mask) {
-  int start_num, end_num, batch_size, prevHour = -1, nchan = 3;  // first maybe overexposed images (mono !) making problems 
+  int start_num, end_num, batch_size, prevHour = -1, nchan = cf->fixed_channel_number;  // first maybe overexposed images (mono !) making problems 
   unsigned long nfiles = files->gl_pathc;
   cv::Mat thread_accumulator;
 
@@ -383,6 +384,7 @@ void parse_args(int argc, char** argv, struct config_t* cf) {
   cf->img_expand = false;
   cf->num_img_expand = 1;
   cf->channel_info = false;
+  cf->fixed_channel_number = 0;
 
   while (1) {  // getopt loop
     int option_index = 0;
@@ -405,9 +407,10 @@ void parse_args(int argc, char** argv, struct config_t* cf) {
         {"help", no_argument, 0, 'h'},
         {"image-expand", no_argument, 0, 'x'},
         {"channel-info", no_argument, 0, 'c'},
+        {"fixed-channel-number", required_argument, 0, 'f'},
         {0, 0, 0, 0}};
 
-    c = getopt_long(argc, argv, "d:e:o:r:s:L:C:N:S:T:Q:q:npvhxc", long_options,
+    c = getopt_long(argc, argv, "d:e:o:r:s:L:C:N:S:T:Q:q:f:npvhxc", long_options,
                     &option_index);
     if (c == -1)
       break;
@@ -429,6 +432,9 @@ void parse_args(int argc, char** argv, struct config_t* cf) {
         break;
       case 'c':
         cf->channel_info = true;
+        break;
+      case 'f':
+        cf->fixed_channel_number = atoi(optarg);
         break;
       case 'p':
         cf->parse_filename = true;
@@ -555,6 +561,7 @@ void usage_and_exit(int x) {
       << std::endl;
   std::cout << "-x | --image-expand : expand image to get the proportions of source" << std::endl;
   std::cout << "-c | --channel-info : show channel infos - mean value of R/G/B" << std::endl;
+  std::cout << "-f | --fixed-channel-number <int> : define number of channels 0=auto, 1=mono, 3=rgb (0=auto)" << std::endl;
 
   std::cout << KNRM << std::endl;
   std::cout

--- a/src/keogram.cpp
+++ b/src/keogram.cpp
@@ -458,22 +458,20 @@ void parse_args(int argc, char** argv, struct config_t* cf) {
         cf->verbose++;
         break;
       case 'C':
-        // Problems with "255 255 255" -> optarg is only "255 !!!
-        // solved without spaces - ever worked with optargs ???   
-        if (strchr(optarg, ',')) {
+        if (strchr(optarg, ' ')) {
           int r, g, b;
-          sscanf(optarg, "%d,%d,%d", &b, &g, &r);
+          sscanf(optarg, "%d %d %d", &b, &g, &r);
           cf->b = b & 0xff;
           cf->g = g & 0xff;
           cf->r = r & 0xff;
-        } else {
-          if (optarg[0] == '#')  // skip '#' if input is like '#coffee'
-            optarg++;
-          sscanf(optarg, "%06x", &tmp);
-          cf->b = tmp & 0xff;
-          cf->g = (tmp >> 8) & 0xff;
-          cf->r = (tmp >> 16) & 0xff;
+          break;
         }
+        if (optarg[0] == '#')  // skip '#' if input is like '#coffee'
+          optarg++;
+        sscanf(optarg, "%06x", &tmp);
+        cf->b = tmp & 0xff;
+        cf->g = (tmp >> 8) & 0xff;
+        cf->r = (tmp >> 16) & 0xff;
         break;
       case 'L':
         cf->lineWidth = atoi(optarg);

--- a/src/keogram.cpp
+++ b/src/keogram.cpp
@@ -553,6 +553,8 @@ void usage_and_exit(int x) {
   std::cout
       << "-q | --nice-level <int> : nice(2) level of processing threads (10)"
       << std::endl;
+  std::cout << "-x | --image-expand : expand image to get the proportions of source" << std::endl;
+  std::cout << "-c | --channel-info : show channel infos - mean value of R/G/B" << std::endl;
 
   std::cout << KNRM << std::endl;
   std::cout

--- a/src/keogram.cpp
+++ b/src/keogram.cpp
@@ -212,7 +212,7 @@ void keogram_worker(int thread_num,
       if (ft.tm_hour != prevHour) {
         if (prevHour != -1) {
           mtx->lock();
-          cv::Mat a = (cv::Mat_<int>(1, 2) << destCol, ft.tm_hour);
+          cv::Mat a = (cv::Mat_<int>(1, 5) << destCol, ft.tm_hour, ft.tm_year, ft.tm_mon, ft.tm_mday);
           ann->push_back(a);
           mtx->unlock();
         }
@@ -249,12 +249,45 @@ void annotate_image(cv::Mat* ann, cv::Mat* acc, struct config_t* cf) {
                                           cf->lineWidth, &baseline);
 
       if (ann->at<int>(r, 0) - textSize.width >= 0) {
+        // black background
+        cv::putText(*acc, text,
+                    cv::Point(ann->at<int>(r, 0) - textSize.width, 
+                    acc->rows - (textSize.height)),
+                    cf->fontFace, cf->fontScale,
+                    cv::Scalar(0, 0, 0), cf->lineWidth+2,
+                    cf->fontType);
         cv::putText(*acc, text,
                     cv::Point(ann->at<int>(r, 0) - textSize.width,
-                              acc->rows - textSize.height),
+                    acc->rows - textSize.height),
                     cf->fontFace, cf->fontScale,
                     cv::Scalar(cf->b, cf->g, cf->r), cf->lineWidth,
                     cf->fontType);
+      }
+
+      if (ann->at<int>(r, 1) == 0) {
+        // Draw date
+        char    time_buf[256];
+        snprintf(time_buf, 256, "%02d-%02d-%02d", ann->at<int>(r, 3), ann->at<int>(r, 4), ann->at<int>(r, 2));
+        std::string text(time_buf);
+        cv::Size textSize = cv::getTextSize(text, cf->fontFace, cf->fontScale,
+                                          cf->lineWidth, &baseline);
+
+        if (ann->at<int>(r, 0) - textSize.width >= 0) {
+          // black background
+          cv::putText(*acc, text,
+                      cv::Point(ann->at<int>(r, 0) - textSize.width, 
+                      acc->rows - (2.5 * textSize.height)),
+                      cf->fontFace, cf->fontScale,
+                      cv::Scalar(0, 0, 0), cf->lineWidth+2,
+                      cf->fontType);
+          // Text
+          cv::putText(*acc, text,
+                      cv::Point(ann->at<int>(r, 0) - textSize.width, 
+                      acc->rows - (2.5 * textSize.height)),
+                      cf->fontFace, cf->fontScale,
+                      cv::Scalar(cf->b, cf->g, cf->r), cf->lineWidth,
+                      cf->fontType);
+        }
       }
     }
   }

--- a/src/startrails.cpp
+++ b/src/startrails.cpp
@@ -60,7 +60,7 @@ void startrail_worker(int thread_num,
                       std::mutex* mtx,
                       cv::Mat* stats_ptr,
                       cv::Mat* main_accumulator) {
-  int start_num, end_num, batch_size, nchan = 0;
+  int start_num, end_num, batch_size, nchan = 3; // first maybe overexposed images (mono !) making problems
   unsigned long nfiles = files->gl_pathc;
   cv::Mat thread_accumulator;
 


### PR DESCRIPTION
1. new parameter -x (expands image to get the proportions of source)
2. new parameter -c (show channel infos - mean value)
3. text with black background
4. show date
5. calculate mean value only in the inner circle (mask) - without steetlights, cars,... 

./keogram_li -d images/20211031 -e jpg -o test_li.jpg -x -c
![test_li](https://user-images.githubusercontent.com/85451655/139644741-a48da16a-0fc1-483b-be1e-5fc3952f0494.jpg)

daylight saving:
![test_li](https://user-images.githubusercontent.com/85451655/139644898-87d0793c-d2e7-48a6-b8c9-b71d73d02810.jpg)

without changes:
![test](https://user-images.githubusercontent.com/85451655/139645420-044b8700-e9a2-4ac5-ac07-853bc605ae46.jpg)


