### PR TITLE
darkSubtract.sh: don't force -type TrueColor

### DIFF
--- a/scripts/darkSubtract.sh
+++ b/scripts/darkSubtract.sh
@@ -82,7 +82,7 @@ if [ "${DARK_FRAME_SUBTRACTION}" = "true" ]; then
 		echo "${ME}: Subtracting dark frame '${CLOSEST_TEMPERATURE}.${EXTENSION}' from image with TEMPERATURE=${TEMPERATURE}"
 	fi
 	# Update the current image - don't rename it.
-	convert "${CURRENT_IMAGE}" "${DARK}" -compose minus_src -composite -type TrueColor "${CURRENT_IMAGE}"
+	convert "${CURRENT_IMAGE}" "${DARK}" -compose minus_src -composite "${CURRENT_IMAGE}"
 	if [ $? -ne 0 ]; then
 		# Exit since we don't know the state of ${CURRENT_IMAGE}.
 		echo "*** ${ME}: ERROR: 'convert' of '${DARK}' failed"


### PR DESCRIPTION
The "convert" command is smart enough to determine what bit depth the output file should be based on the input file and the dark file, so we don't need to force TrueColor (24 bit).  This causes problems because daytime mono images are 8-bit (no dark subtraction is done) but nighttime images are 24-bit.