### PR TITLE
bugfix I780: as other programs using cv::IMWRITE_...

### DIFF
--- a/src/mode_RPiHQ_mean.cpp
+++ b/src/mode_RPiHQ_mean.cpp
@@ -56,9 +56,9 @@ void RPiHQmask(const char* fileName)
 		dstImage = cv::Mat::zeros(image.size(), CV_8U);
 		cv::Mat maskHorizon;
     	std::vector<int> compression_params;
-    	compression_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+    	compression_params.push_back(cv::IMWRITE_PNG_COMPRESSION);
     	compression_params.push_back(9);
-    	compression_params.push_back(CV_IMWRITE_JPEG_QUALITY);
+    	compression_params.push_back(cv::IMWRITE_JPEG_QUALITY);
     	compression_params.push_back(100);
 
 		if (createMaskHorizon) {
@@ -194,9 +194,9 @@ void RPiHQcalcMean(const char* fileName, int asiExposure_us, double asiGain, ras
 /////////////////////////////////////////////////////////////////////////////////////
       
     std::vector<int> compression_params;
-   	compression_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+   	compression_params.push_back(cv::IMWRITE_PNG_COMPRESSION);
    	compression_params.push_back(9);
-   	compression_params.push_back(CV_IMWRITE_JPEG_QUALITY);
+   	compression_params.push_back(cv::IMWRITE_JPEG_QUALITY);
    	compression_params.push_back(95);
 
    	cv::imwrite("test.jpg", dstImage, compression_params);


### PR DESCRIPTION
Quickfix - hopefully
```
pi@allsky:~/allsky_I_780 $ make clean
make[1]: Verzeichnis „/home/pi/allsky_I_780/src“ wird betreten
rm -f capture capture_RPiHQ startrails keogram *.o *.a
make[1]: Verzeichnis „/home/pi/allsky_I_780/src“ wird verlassen
make[1]: Verzeichnis „/home/pi/allsky_I_780/config_repo“ wird betreten
2021-11-11 17:46:04 nothing to do for clean
make[1]: Verzeichnis „/home/pi/allsky_I_780/config_repo“ wird verlassen
make[1]: Verzeichnis „/home/pi/allsky_I_780/notification_images“ wird betreten
2021-11-11 17:46:04 nothing to do for clean...
make[1]: Verzeichnis „/home/pi/allsky_I_780/notification_images“ wird verlassen
make[1]: Verzeichnis „/home/pi/allsky_I_780/scripts“ wird betreten
2021-11-11 17:46:04 nothing to do for clean
make[1]: Verzeichnis „/home/pi/allsky_I_780/scripts“ wird verlassen
pi@allsky:~/allsky_I_780 $ make all
make[1]: Verzeichnis „/home/pi/allsky_I_780/src“ wird betreten
2021-11-11 17:46:07 Building capture program...
2021-11-11 17:46:16 Done.
2021-11-11 17:46:16 Building capture_RPiHQ program...
2021-11-11 17:46:31 Done.
2021-11-11 17:46:31 Building startrails program...
2021-11-11 17:46:43 Done.
2021-11-11 17:46:43 Building keogram program...
2021-11-11 17:46:56 Done.
make[1]: Verzeichnis „/home/pi/allsky_I_780/src“ wird verlassen
make[1]: Verzeichnis „/home/pi/allsky_I_780/config_repo“ wird betreten
2021-11-11 17:46:56 nothing to do for all
make[1]: Verzeichnis „/home/pi/allsky_I_780/config_repo“ wird verlassen
make[1]: Verzeichnis „/home/pi/allsky_I_780/notification_images“ wird betreten
2021-11-11 17:46:56 nothing to do for all...
make[1]: Verzeichnis „/home/pi/allsky_I_780/notification_images“ wird verlassen
make[1]: Verzeichnis „/home/pi/allsky_I_780/scripts“ wird betreten
2021-11-11 17:46:56 nothing to do for all
make[1]: Verzeichnis „/home/pi/allsky_I_780/scripts“ wird verlassen
```

resolve #780 