### PR TITLE
Use BASH_SOURCE[0] instead of $0

### DIFF
--- a/scripts/darkSubtract.sh
+++ b/scripts/darkSubtract.sh
@@ -66,9 +66,9 @@ if [ "${DARK_FRAME_SUBTRACTION}" = "true" ]; then
 				
 				echo -n "${ME}: INFORMATION: dark file '${DARKS_DIR}/${file}' "
 				if [ ! -f "${DARKS_DIR}/${file}" ]; then
-					echo "$is does not exist  Huh?."
+					echo "${file} does not exist  Huh?."
 				else
-					echo "$is zero-length; deleting."
+					echo "${file} zero-length; deleting."
 					ls -l "${DARKS_DIR}/${file}"
 					rm -f "${DARKS_DIR}/${file}"
 				fi

--- a/scripts/darkSubtract.sh
+++ b/scripts/darkSubtract.sh
@@ -3,7 +3,7 @@
 # This file is "source"d into another.
 # "${CURRENT_IMAGE}" is the name of the current image we're working on.
 
-ME="$(basename "${BASH_ARGV0}")"
+ME="$(basename "${BASH_SOURCE[0]}")"
 
 # Subtract dark frame if there is one defined in config.sh
 # This has to come after executing darkCapture.sh which sets ${TEMPERATURE}.

--- a/scripts/darkSubtract.sh
+++ b/scripts/darkSubtract.sh
@@ -63,8 +63,15 @@ if [ "${DARK_FRAME_SUBTRACTION}" = "true" ]; then
 				CLOSEST_TEMPERATURE=${DARK_TEMPERATURE}
 				let DIFF=${TEMPERATURE}-${CLOSEST_TEMPERATURE}
 			else
-				echo "${ME}: INFORMATION: dark file '${DARKS_DIR}/${file}' is zero-length; deleting."
-				rm -f "${DARKS_DIR}/${file}"
+				
+				echo -n "${ME}: INFORMATION: dark file '${DARKS_DIR}/${file}' "
+				if [ ! -f "${DARKS_DIR}/${file}" ]; then
+					echo "$is does not exist  Huh?."
+				else
+					echo "$is zero-length; deleting."
+					ls -l "${DARKS_DIR}/${file}"
+					rm -f "${DARKS_DIR}/${file}"
+				fi
 			fi
 		done
 

--- a/variables.sh
+++ b/variables.sh
@@ -9,16 +9,18 @@ if [ "${ALLSKY_VARIABLE_SET}" = "" ]; then
 
 	ALLSKY_VARIABLE_SET="true"	# so we only do the following once
 
-	ME="$(basename "${BASH_ARGV0}")"
+	ME="$(basename "${BASH_SOURCE[0]}")"
 
 	# Set colors used by many scripts in output.
 	# If we're not on a tty output is likely being written to a file, so don't use colors.
 	if tty --silent ; then
+		ON_TTY=1
 		RED="\033[0;31m"
 		GREEN="\033[0;32m"
 		YELLOW="\033[0;33m"
 		NC="\033[0m" # No Color
 	else
+		ON_TTY=0
 		RED=""
 		GREEN=""
 		YELLOW=""
@@ -32,11 +34,6 @@ if [ "${ALLSKY_VARIABLE_SET}" = "" ]; then
 		exit 1
 	fi
 
-	if tty --silent ; then
-		ON_TTY=1
-	else
-		ON_TTY=0
-	fi
 	# Allow variables to be overridden for testing or to use different locations.
 
 	# For temporary files or files that can be deleted at reboot.


### PR DESCRIPTION
When a file is "source"d into another, $0 in the "source"d file takes the name of the invoking script.
Using BASH_SOURCE[0] in the invoked script prints its name.