### PR TITLE
allsky.sh: exit after msg about Bullseye

### DIFF
--- a/allsky.sh
+++ b/allsky.sh
@@ -197,6 +197,7 @@ elif [[ $CAMERA == "RPiHQ" ]]; then
 
 		# Don't let the service restart us 'cause we'll get the same error again
 		sudo systemctl stop allsky
+		exit 99
 	fi
 fi
 "${ALLSKY_HOME}/${CAPTURE}" "${ARGUMENTS[@]}"


### PR DESCRIPTION
Exit if the user is running on Bullseye with a Pi.  capture_RPiHQ doesn't support Bullseye yet so they'll get errors.