### PR TITLE
darkCapture.sh: always output 2-digit temp

### DIFF
--- a/scripts/darkCapture.sh
+++ b/scripts/darkCapture.sh
@@ -8,7 +8,7 @@
 if [ "${TEMPERATURE}" = "" ]; then
 	TEMPERATURE_FILE="${ALLSKY_HOME}/temperature.txt"
 	if [ -s "${TEMPERATURE_FILE}" ]; then	# -s so we don't use an empty file
-		TEMPERATURE=$(printf "%2.0f" "$(< ${TEMPERATURE_FILE})")
+		TEMPERATURE=$(printf "%02.0f" "$(< ${TEMPERATURE_FILE})")
 	else
 		TEMPERATURE="n/a"
 	fi


### PR DESCRIPTION
%2f produced files with leading spaces, which broke darkSubtract.sh
No need for 3-digit temps since they are in Celsius and if someone has 100+ C sensor it'll fry.