### PR TITLE
capture_RPiHQ.cpp: compiler warning

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -626,7 +626,7 @@ ASI_ERROR_CODE takeOneExposure(
 	if (currentAutoExposure == ASI_TRUE && exposure_time_us > current_max_autoexposure_us)
 	{
 		// If we call length_in_units() twice in same command line they both return the last value.
-		char x[20];
+		char x[100];
 		snprintf(x, sizeof(x), "%s", length_in_units(exposure_time_us, true));
 		Log(0, "*** WARNING: exposure_time_us requested [%s] > current_max_autoexposure_us [%s]\n", x, length_in_units(current_max_autoexposure_us, true));
 		exposure_time_us = current_max_autoexposure_us;

--- a/src/capture_RPiHQ.cpp
+++ b/src/capture_RPiHQ.cpp
@@ -828,6 +828,8 @@ const char *locale         = DEFAULT_LOCALE;
 	char const *ImgText   = "";
 	char const *ImgExtraText   = "";
 	int extraFileAge           = 0;   // 0 disables it
+// The "extra text" file hasn't been implemented in RPiHQ.  The next line keeps the compiler quiet so users don't think there's a problem.
+if (extraFileAge == 99999 && ImgExtraText[0] == '\0') ImgExtraText = "xxxxxx   keep compiler quiet";
 #define DEFAULT_FONTSIZE    32
 	double fontsize       = DEFAULT_FONTSIZE;
 #define SMALLFONTSIZE_MULTIPLIER 0.08
@@ -1645,7 +1647,7 @@ const char *locale         = DEFAULT_LOCALE;
 				{
 					long last_exposure_us = currentExposure_us;
 
-					float actualGain = currentGain; // to be compatible with ZWO - ZWO gain=0.1 dB , RPiHQ gain=factor
+					float actualGain = currentGain;	// to be compatible with ZWO - ZWO gain=0.1 dB , RPiHQ gain=factor
 					if (myModeMeanSetting.mode_mean)
 						actualGain =  myRaspistillSetting.analoggain;
 					int iYOffset = 0;


### PR DESCRIPTION
The "extra text" file hasn't yet been fully implemented in the RPiHQ capture program, but variables to activate it are there.  This causes compiler messages about "variable set but not used".  This is not an issue, but some users have mentioned it, thinking it's an error.
I added a dummy line to keep the compiler quiet.  This line will be removed when the "extra text" file is implemented.

Fixes #833.