### PR TITLE
Update removeBadImages.sh

### DIFF
--- a/scripts/removeBadImages.sh
+++ b/scripts/removeBadImages.sh
@@ -79,6 +79,7 @@ cd "${DATE}"
 if [ "${FILE}" != "" ]; then
 	IMAGE_FILES="${FILE}"
 else
+	set +a	# turn off auto-export since $IMAGE_FILES might be HUGE, producing errors later
 	IMAGE_FILES="$( find . -type f -iname "${FILENAME}"-\*.${EXTENSION} \! -ipath \*thumbnail\* )"
 fi
 ERROR_WORDS="Huffman|Bogus|Corrupt|Invalid|Trunc|Missing|insufficient image data|no decode delegate|no images defined"


### PR DESCRIPTION
Fixes #855
variables.sh does a "set -a" which automatically exports all variables.
removeBadImages.sh sets IMAGE_FILES to the name of all the images in a directory, which can be HUGE, causing subsequent commands to fail with "argument list too long".