### PR TITLE
generateForDay.sh: bug in args to timelapse.sh

### DIFF
--- a/scripts/generateForDay.sh
+++ b/scripts/generateForDay.sh
@@ -204,7 +204,7 @@ if [ "${DO_TIMELAPSE}" = "true" ] ; then
 	VIDEOS_FILE="allsky-${DATE}.mp4"
 	UPLOAD_FILE="${DATE_DIR}/${VIDEOS_FILE}"
 	if [ "${TYPE}" = "GENERATE" ]; then
-		CMD="'${ALLSKY_SCRIPTS}/timelapse.sh' ${DATE} ${TIMELAPSE_EXTRA_PARAMETERS}"
+		CMD="'${ALLSKY_SCRIPTS}/timelapse.sh' ${DATE}"
 		generate "Timelapse" "" "${CMD}"	# it creates the necessary directory
 		let EXIT_CODE=${EXIT_CODE}+${?}
 	else


### PR DESCRIPTION
$TIMELAPSE_EXTRA_PARAMETERS should NOT be passed to timelapse.sh since it's in config.sh and is already on the command line for ffmpeg in timelapse.sh.

Fixes #866