### PR TITLE
generateForDay.sh: upload message fix

### DIFF
--- a/scripts/generateForDay.sh
+++ b/scripts/generateForDay.sh
@@ -214,7 +214,7 @@ if [ "${DO_TIMELAPSE}" = "true" ] ; then
 fi
 
 
-if [ "${TYPE}" = "GENERATE" -a ${SILENT} = "false" ]; then
+if [ "${TYPE}" = "GENERATE" -a ${SILENT} = "false" -a ${EXIT_CODE} -eq 0 ]; then
 	ARGS=""
 	[ "${DO_KEOGRAM}" = "true" ] && ARGS="${ARGS} -k"
 	[ "${DO_STARTRAILS}" = "true" ] && ARGS="${ARGS} -s"


### PR DESCRIPTION
Only show the "upload" message if file creation worked, i.e., $EXIT_CODE = 0.