### PR TITLE
Capture_RPiHQ.cpp: use %03d

### DIFF
--- a/src/capture_RPiHQ.cpp
+++ b/src/capture_RPiHQ.cpp
@@ -1900,7 +1900,7 @@ if (WIFSIGNALED(r)) r = WTERMSIG(r);
 			strcat(cmd, tmp);
 			snprintf(tmp, sizeof(tmp), " BIT_DEPTH=%02d", current_bit_depth);
 			strcat(cmd, tmp);
-			snprintf(tmp, sizeof(tmp), " FOCUS=%3d", focus_metric);
+			snprintf(tmp, sizeof(tmp), " FOCUS=%03d", focus_metric);
 			strcat(cmd, tmp);
 
 			strcat(cmd, " &");


### PR DESCRIPTION
With just %3d it would put a space in the argument value which saveImage,sh treated as two arguments instead of one.