### PR TITLE
Image not available when uploading to server

### DIFF
--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -144,7 +144,7 @@ if [ "${DAYTIME_SAVE}" = "true" -o "${DAY_OR_NIGHT}" = "NIGHT" ] ; then
 	cp "${IMAGE_TO_USE}" "${FINAL_FILE}" || echo "*** ERROR: ${ME}: unable to copy ${IMAGE_TO_USE} ***"
 	IMAGE_TO_USE="${FINAL_FILE}"
 fi
-mv "${IMAGE_TO_USE}" "${WORKING_DIR}/${FULL_FILENAME}"	# Websites look for $FULL_FILENAME
+cp "${IMAGE_TO_USE}" "${WORKING_DIR}/${FULL_FILENAME}"	# Websites look for $FULL_FILENAME
 
 # If upload is true, optionally create a smaller version of the image; either way, upload it
 if [ "${UPLOAD_IMG}" = "true" ] ; then


### PR DESCRIPTION
The current image gets moved into ${WORKING_DIR}/${FULL_FILENAME} before it is uploaded to the server. During the upload the image then cannot be found and an error is thrown.

**Solutions**
- I just copied (instead of moved) the image away into ${WORKING_DIR}/${FULL_FILENAME}
- another solution would be to set ${IMAGE_TO_USE} to ${WORKING_DIR}/${FULL_FILENAME} but then the timestamp within the filename is lost.