### PR TITLE
startrails.cpp: remove ALLSKY_DEBUG_LEVEL

### DIFF
--- a/src/startrails.cpp
+++ b/src/startrails.cpp
@@ -316,11 +316,6 @@ int main(int argc, char* argv[]) {
 
   parse_args(argc, argv, &config);
 
-  if (config.verbose < 1)
-    if ((e = getenv("ALLSKY_DEBUG_LEVEL")))
-      if ((i = atoi(e)) > 0)
-        config.verbose = i;
-
   if (config.img_src_dir.empty() || config.img_src_ext.empty())
     usage_and_exit(3);
 


### PR DESCRIPTION
When troubleshooting users' issues we tell them to set Debug Level to 4, which sets ALLSKY_DEBUG_LEVEL to 4.  We almost never want debug output from startrails.cpp, especially one line for each images (potentially thousands) cluttering up the log file.
If we, or users, want debug output from startrails.cpp they can add "--verbose" to STARTRAILS_EXTRA_PARAMETERS.