### PR TITLE
Remove leading zeros

### DIFF
--- a/scripts/darkSubtract.sh
+++ b/scripts/darkSubtract.sh
@@ -37,7 +37,7 @@ if [ "${DARK_FRAME_SUBTRACTION}" = "true" ]; then
 		# Find the closest dark frame temperature wise
 		typeset -i CLOSEST_TEMPERATURE	# don't set yet
 		typeset -i DIFF=100		# any sufficiently high number
-		typeset -i THIS_TEMPERATURE=${THIS_TEMPERATURE}
+		typeset -i THIS_TEMPERATURE=${THIS_TEMPERATURE##0}
 		typeset -i OVERDIFF		# DIFF when dark file temp > ${THIS_TEMPERATURE}
 		typeset -i DARK_TEMPERATURE
 

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -361,9 +361,9 @@ void *SaveImgThd(void *para)
 
 			// TEMPERATURE, GAIN, and BIN are used by the dark* scripts to sort and compare against
 			// prior values, so make them fixed width to aid in doing that.
-			snprintf(tmp, sizeof(tmp), " TEMPERATURE=%02d", (int)round(actualTemp/10));
+			snprintf(tmp, sizeof(tmp), " TEMPERATURE=%d", (int)round(actualTemp/10));
 			strcat(cmd, tmp);
-			snprintf(tmp, sizeof(tmp), " GAINDB=%03d", currentGain);
+			snprintf(tmp, sizeof(tmp), " GAINDB=%d", currentGain);
 			strcat(cmd, tmp);
 			snprintf(tmp, sizeof(tmp), " GAIN=%1.2f", pow(10, (float)currentGain / 10.0 / 20.0));
 			strcat(cmd, tmp);
@@ -371,7 +371,7 @@ void *SaveImgThd(void *para)
 			strcat(cmd, tmp);
 			snprintf(tmp, sizeof(tmp), " FLIP=%d", asiFlip);
 			strcat(cmd, tmp);
-			snprintf(tmp, sizeof(tmp), " BIT_DEPTH=%02d", current_bit_depth);
+			snprintf(tmp, sizeof(tmp), " BIT_DEPTH=%d", current_bit_depth);
 			strcat(cmd, tmp);
 
 			strcat(cmd, " &");

--- a/src/capture_RPiHQ.cpp
+++ b/src/capture_RPiHQ.cpp
@@ -1888,19 +1888,19 @@ if (WIFSIGNALED(r)) r = WTERMSIG(r);
 			// prior values, so make them fixed width to aid in doing that.
 
 			// There's currently no way to get to the RPiHQ camera's temperature sensor.
-			//snprintf(tmp, sizeof(tmp), " TEMPERATURE=%02d", (int)round(actualTemp/10));
+			//snprintf(tmp, sizeof(tmp), " TEMPERATURE=%d", (int)round(actualTemp/10));
 			//strcat(cmd, tmp);
 			snprintf(tmp, sizeof(tmp), " GAIN=%1.2f", last_gain);
 			strcat(cmd, tmp);
-			snprintf(tmp, sizeof(tmp), " GAINDB=%03d", (int)round(20.0 * 10.0 * log10(last_gain)));
+			snprintf(tmp, sizeof(tmp), " GAINDB=%d", (int)round(20.0 * 10.0 * log10(last_gain)));
 			strcat(cmd, tmp);
 			snprintf(tmp, sizeof(tmp), " BIN=%d", currentBin);
 			strcat(cmd, tmp);
 			snprintf(tmp, sizeof(tmp), " FLIP=%d", asiFlip);
 			strcat(cmd, tmp);
-			snprintf(tmp, sizeof(tmp), " BIT_DEPTH=%02d", current_bit_depth);
+			snprintf(tmp, sizeof(tmp), " BIT_DEPTH=%d", current_bit_depth);
 			strcat(cmd, tmp);
-			snprintf(tmp, sizeof(tmp), " FOCUS=%03d", focus_metric);
+			snprintf(tmp, sizeof(tmp), " FOCUS=%d", focus_metric);
 			strcat(cmd, tmp);
 
 			strcat(cmd, " &");


### PR DESCRIPTION
Bash treats numbers with a leading 0 as octal, so if we try to convert the string "09" to an integer it'll complain that "9" isn't an octal number.  So, don't pass numbers to saveImage.sh with leading zero's.  If saveImage.sh or another script want a fixed length number, it can create it in the desired format.  For example, "9" can be converted to "09".

This bug breaks anyone with dark images taken when the sensor is either 8 or 9 degrees (which happened).