### PR TITLE
Allow web install over prior version

### DIFF
--- a/website/install.sh
+++ b/website/install.sh
@@ -35,6 +35,49 @@ modify_locations() {	# Some files have placeholders for certain locations.  Modi
 	)
 }
 
+modify_configuration_variables() {	# Update some of the configuration variables
+	# If the user is updating the website, use the prior config files.
+	# NOTE: if we add/delete a setting in the files we'll need to change the code below.
+
+	if [ "${SAVED_OLD}" = "true" ]; then
+		echo -e "${GREEN}* Retoring prior 'config.js' and 'virtualsky.json' files.${NC}"
+		cp "${WEBSITE_DIR_OLD}/config.js "${WEBSITE_DIR_OLD}/virtualsky.json "${WEBSITE_DIR}"
+	else
+		echo -e "${GREEN}* Updating settings in ${WEBSITE_DIR}/config.js${NC}"
+		# These have N/S and E/W but the config.js needs decimal numbers.
+		# "N" is positive, "S" negative for LATITUDE.
+		# "E" is positive, "W" negative for LONGITUDE.
+		LATITUDE=$(jq -r '.latitude' "$CAMERA_SETTINGS")
+		DIRECTION=${LATITUDE:1,-1}
+		if [ "${DIRECTION}" = "S" ]; then
+			SIGN="-"
+			AURORAMAP="south"
+		else
+			SIGN=""
+			AURORAMAP="north"
+		fi
+		LATITUDE="${SIGN}${LATITUDE%${DIRECTION}}"
+
+		LONGITUDE=$(jq -r '.longitude' "$CAMERA_SETTINGS")
+		DIRECTION=${LONGITUDE:1,-1}
+		if [ "${DIRECTION}" = "W" ]; then
+			SIGN="-"
+		else
+			SIGN=""
+		fi
+		LONGITUDE="${SIGN}${LONGITUDE%${DIRECTION}}"
+		COMPUTER=$(tail -1 /proc/cpuinfo | sed 's/.*: //')
+		# xxxx TODO: anything else we can set?
+		sed -i \
+			-e "/latitude:/c\    latitude: ${LATITUDE}," \
+			-e "/longitude:/c\    longitude: ${LONGITUDE}," \
+			-e "/auroraMap:/c\    auroraMap: \"${AURORAMAP}\"," \
+			-e "/computer:/c\    computer: \"${COMPUTER}\"," \
+				"${WEBSITE_DIR}/config.js"
+	fi
+}
+
+
 # Check if the user is updating an existing installation.
 if [ "${1}" = "--update" -o "${1}" = "-update" ] ; then
 	shift
@@ -47,8 +90,19 @@ if [ "${1}" = "--update" -o "${1}" = "-update" ] ; then
 	exit 0		# currently nothing else to do for updates
 fi
 
-echo -e "${GREEN}* Fetching website files into ${WEBSITE_DIR}${NC}"
+if [ -d "${WEBSITE_DIR}" ]; then
+	# git will fail if the directory already exists
+	WEBSITE_DIR_OLD="${WEBSITE_DIR}-OLD"
+	echo -e "${GREEN}* Saving old website to '${WEBSITE_DIR_OLD}'${NC}"
+	mv "${WEBSITE_DIR}" "${WEBSITE_DIR_OLD}"
+	SAVED_OLD=true
+else
+	SAVED_OLD=false
+fi
+
+echo -e "${GREEN}* Fetching website files into '${WEBSITE_DIR}'${NC}"
 git clone https://github.com/thomasjacquin/allsky-website.git "${WEBSITE_DIR}"
+[ $? -ne 0 ] && echo -e "\n${RED}Exiting installation${NC}\n" && exit 1
 echo
 
 cd "${WEBSITE_DIR}"
@@ -67,39 +121,40 @@ if [ ! -d startrails/thumbnails -o ! -d keograms/thumbnails -o ! -d videos/thumb
 fi
 
 modify_locations
+modify_configuration_variables
 
-echo -e "${GREEN}* Updating settings in ${WEBSITE_DIR}/config.js${NC}"
-# These have N/S and E/W but the config.js needs decimal numbers.
-# "N" is positive, "S" negative for LATITUDE.
-# "E" is positive, "W" negative for LONGITUDE.
-LATITUDE=$(jq -r '.latitude' "$CAMERA_SETTINGS")
-DIRECTION=${LATITUDE:1,-1}
-if [ "${DIRECTION}" = "S" ]; then
-	SIGN="-"
-	AURORAMAP="south"
-else
-	SIGN=""
-	AURORAMAP="north"
+if [ "${SAVED_OLD}" = "true" ]; then
+	# Each directory has one .php file plus zero or more images.
+	# Move the thumbnails first so it doesn't appear in the count.
+
+	if [ -d "${WEBSITE_DIR_OLD}/videos/thumbnails" ]; then
+		mv "${WEBSITE_DIR_OLD}/videos/thumbnails" videos
+	fi
+	count=$(ls -1 "${WEBSITE_DIR_OLD}/videos" | wc -l)
+	if [ "${count}" -gt 1 ]; then
+		echo -e "${GREEN}* Restoring prior videos${NC}"
+		mv "${WEBSITE_DIR_OLD}"/videos/allsky-* videos
+	fi
+
+	if [ -d "${WEBSITE_DIR_OLD}/keograms/thumbnails" ]; then
+		mv "${WEBSITE_DIR_OLD}/keograms/thumbnails" keograms
+	fi
+	count=$(ls -1 "${WEBSITE_DIR_OLD}/keograms" | wc -l)
+	if [ "${count}" -gt 1 ]; then
+		echo -e "${GREEN}* Restoring prior keograms${NC}"
+		mv "${WEBSITE_DIR_OLD}"/keograms/keogram-* keograms
+	fi
+
+	if [ -d "${WEBSITE_DIR_OLD}/startrails/thumbnails" ]; then
+		mv "${WEBSITE_DIR_OLD}/startrails/thumbnails" startrails
+	fi
+	count=$(ls -1 "${WEBSITE_DIR_OLD}/startrails" | wc -l)
+	if [ "${count}" -gt 1 ]; then
+		echo -e "${GREEN}* Restoring prior startrails${NC}"
+		mv "${WEBSITE_DIR_OLD}"/startrails/startrails-* startrails
+	fi
+set +x
 fi
-LATITUDE="${SIGN}${LATITUDE%${DIRECTION}}"
-
-LONGITUDE=$(jq -r '.longitude' "$CAMERA_SETTINGS")
-DIRECTION=${LONGITUDE:1,-1}
-if [ "${DIRECTION}" = "W" ]; then
-	SIGN="-"
-else
-	SIGN=""
-fi
-LONGITUDE="${SIGN}${LONGITUDE%${DIRECTION}}"
-COMPUTER=$(tail -1 /proc/cpuinfo | sed 's/.*: //')
-# xxxx TODO: anything else we can set?
-sed -i \
-	-e "/latitude:/c\    latitude: ${LATITUDE}," \
-	-e "/longitude:/c\    longitude: ${LONGITUDE}," \
-	-e "/auroraMap:/c\    auroraMap: \"${AURORAMAP}\"," \
-	-e "/computer:/c\    computer: \"${COMPUTER}\"," \
-		"${WEBSITE_DIR}/config.js"
-
 
 echo
 echo -e "${GREEN}* Installation complete${NC}"
@@ -110,6 +165,11 @@ echo    "+++++++++++++++++++++++++++++++++++++"
 echo    "Before using the website you should:"
 echo -e "   * Edit ${YELLOW}${WEBSITE_DIR}/config.js${NC}"
 echo -e "   * Look at, and possibly edit ${YELLOW}${WEBSITE_DIR}/virtualsky.json${NC}"
+if [ "${SAVED_OLD}" = "true" ]; then
+	echo -e "Your prior versions are in '${WEBSITE_DIR_OLD}'"
+	echo -e "\n${YELLOW}After you are convinced everything is working,"
+	echo -e "remove your prior version at '${WEBSITE_DIR_OLD}'.${NC}\n"
+fi
 if [ "${POST_END_OF_NIGHT_DATA}" != "true" ]; then
 	echo "   * Set 'POST_END_OF_NIGHT_DATA=true' in ${ALLSKY_CONFIG}/config.sh"
 fi

--- a/website/install.sh
+++ b/website/install.sh
@@ -41,7 +41,7 @@ modify_configuration_variables() {	# Update some of the configuration variables
 
 	if [ "${SAVED_OLD}" = "true" ]; then
 		echo -e "${GREEN}* Retoring prior 'config.js' and 'virtualsky.json' files.${NC}"
-		cp "${WEBSITE_DIR_OLD}/config.js "${WEBSITE_DIR_OLD}/virtualsky.json "${WEBSITE_DIR}"
+		cp "${WEBSITE_DIR_OLD}/config.js" "${WEBSITE_DIR_OLD}/virtualsky.json" "${WEBSITE_DIR}"
 	else
 		echo -e "${GREEN}* Updating settings in ${WEBSITE_DIR}/config.js${NC}"
 		# These have N/S and E/W but the config.js needs decimal numbers.
@@ -82,7 +82,8 @@ modify_configuration_variables() {	# Update some of the configuration variables
 if [ "${1}" = "--update" -o "${1}" = "-update" ] ; then
 	shift
 	if [ ! -d "${WEBSITE_DIR}" ]; then
-		echo -e "${RED}Update specified but no existing website found in '${WEBSITE_DIR}'${NC}" 1>&2
+		echo -e "${RED}*** ERROR: Update specified but no existing website found in '${WEBSITE_DIR}'${NC}" 1>&2
+		echo
 		exit 2
 	fi
 
@@ -95,6 +96,11 @@ if [ -d "${WEBSITE_DIR}" ]; then
 	WEBSITE_DIR_OLD="${WEBSITE_DIR}-OLD"
 	echo -e "${GREEN}* Saving old website to '${WEBSITE_DIR_OLD}'${NC}"
 	mv "${WEBSITE_DIR}" "${WEBSITE_DIR_OLD}"
+	if [ $? -ne 0 ]; then
+		echo -e "${RED}*** ERROR: Unable to save old website.  Exiting.${NC}" 1>&2
+		echo
+		exit 3
+	fi
 	SAVED_OLD=true
 else
 	SAVED_OLD=false
@@ -102,7 +108,7 @@ fi
 
 echo -e "${GREEN}* Fetching website files into '${WEBSITE_DIR}'${NC}"
 git clone https://github.com/thomasjacquin/allsky-website.git "${WEBSITE_DIR}"
-[ $? -ne 0 ] && echo -e "\n${RED}Exiting installation${NC}\n" && exit 1
+[ $? -ne 0 ] && echo -e "\n${RED}*** ERROR: Exiting installation${NC}\n" && exit 4
 echo
 
 cd "${WEBSITE_DIR}"
@@ -153,24 +159,25 @@ if [ "${SAVED_OLD}" = "true" ]; then
 		echo -e "${GREEN}* Restoring prior startrails${NC}"
 		mv "${WEBSITE_DIR_OLD}"/startrails/startrails-* startrails
 	fi
-set +x
 fi
 
 echo
 echo -e "${GREEN}* Installation complete${NC}"
 echo
 
-# In the meantime, let the user know to do it.
 echo    "+++++++++++++++++++++++++++++++++++++"
-echo    "Before using the website you should:"
-echo -e "   * Edit ${YELLOW}${WEBSITE_DIR}/config.js${NC}"
-echo -e "   * Look at, and possibly edit ${YELLOW}${WEBSITE_DIR}/virtualsky.json${NC}"
 if [ "${SAVED_OLD}" = "true" ]; then
-	echo -e "Your prior versions are in '${WEBSITE_DIR_OLD}'"
-	echo -e "\n${YELLOW}After you are convinced everything is working,"
-	echo -e "remove your prior version at '${WEBSITE_DIR_OLD}'.${NC}\n"
+	echo -e "Your prior website is in '${WEBSITE_DIR_OLD}'."
+	echo    "All your prior videos, keograms, and startrails, as well as prior configuration files"
+	echo    "were MOVED to the updated website".
+	echo -e "\nAfter you are convinced everything is working remove your prior version.\n"
+else
+	echo    "Before using the website you should:"
+	echo -e "   * Edit ${YELLOW}${WEBSITE_DIR}/config.js${NC}"
+	echo -e "   * Look at, and possibly edit ${YELLOW}${WEBSITE_DIR}/virtualsky.json${NC}"
+	echo    "     See https://github.com/thomasjacquin/allsky/wiki/allsky-website-Settings for more information".
 fi
 if [ "${POST_END_OF_NIGHT_DATA}" != "true" ]; then
-	echo "   * Set 'POST_END_OF_NIGHT_DATA=true' in ${ALLSKY_CONFIG}/config.sh"
+	echo    "   * Set 'POST_END_OF_NIGHT_DATA=true' in ${ALLSKY_CONFIG}/config.sh"
 fi
 echo

--- a/website/install.sh
+++ b/website/install.sh
@@ -30,8 +30,9 @@ modify_locations() {	# Some files have placeholders for certain locations.  Modi
 	(
 		cd "${WEBSITE_DIR}"
 
-		# NOTE: Only want to replace the FIRST instance of XX_ALLSKY_CONFIG_XX.
-		sed -i "0,/XX_ALLSKY_CONFIG_XX/{s;XX_ALLSKY_CONFIG_XX;${ALLSKY_CONFIG};}" functions.php
+		sed -i -e "s;XX_ALLSKY_CONFIG_XX;${ALLSKY_CONFIG};" \
+			   -e "s;XX_ON_PI_XX;true;" \
+			functions.php
 	)
 }
 
@@ -88,7 +89,7 @@ if [ "${1}" = "--update" -o "${1}" = "-update" ] ; then
 	fi
 
 	modify_locations
-	
+
 	echo
 	echo -e "${GREEN}* Update complete${NC}"
 	echo

--- a/website/install.sh
+++ b/website/install.sh
@@ -88,6 +88,10 @@ if [ "${1}" = "--update" -o "${1}" = "-update" ] ; then
 	fi
 
 	modify_locations
+	
+	echo
+	echo -e "${GREEN}* Update complete${NC}"
+	echo
 	exit 0		# currently nothing else to do for updates
 fi
 


### PR DESCRIPTION
This PR lets users install updates to the Allsky website via `~/allsky/website/install.sh`.  It saves their timelapse, keograms, startrails, and configuration files, then restores them after the update.