### PR TITLE
cleanup: makeSunwaitWarningFree

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -113,6 +113,7 @@ sunwait:
 	@git submodule init
 	@git submodule update
 	@echo `date +%F\ %R:%S` Building sunwait...
+	@sed -i -e "s/CFLAGS=/CFLAGS=-w /" sunwait-src/makefile
 	@$(MAKE) -C sunwait-src
 	@cp sunwait-src/sunwait .
 	@echo `date +%F\ %R:%S` Done.


### PR DESCRIPTION
Please excuse this dirty solution. Multiple calls can lead to the flag "-w" being inserted multiple times - but this has no effect on the function
But the main advantage is that sunwait is now free of warnings. This avoids concerned inquiries from users and we can now concentrate on our own warnings and errors