### PR TITLE
cleanup: use -Werror

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,7 +39,7 @@ ifneq ($(PKGPATH),)
   OPENCV = $(shell pkg-config --exists opencv && pkg-config --cflags --libs opencv || (pkg-config --exists opencv4 && pkg-config --cflags --libs opencv4))
 endif
 DEFS = -D_LIN -D_DEBUG -DGLIBC_20
-CFLAGS = -Wall -Wno-psabi -Wno-unused-result -g -O2 -lpthread
+CFLAGS = -Werror -Wall -Wno-psabi -Wno-unused-result -g -O2 -lpthread
 
 ifeq ($(platform), armv6l)
   CC = arm-linux-gnueabihf-g++


### PR DESCRIPTION
With this flag all warning are changed into errors.
The main advantage is that the automatic test (action) now immediately alerts us to warnings
If warnings cannot be avoided, this can be switched off in the source code if necessary.