### PR TITLE
Patching sunwait to clear compile warnings

### DIFF
--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -186,14 +186,14 @@ if [ "${UPLOAD_IMG}" = "true" ] ; then
 		# Put the copy in ${WORKING_DIR}.
 		FILE_TO_UPLOAD="${WORKING_DIR}/resize-${IMAGE_NAME}"
 		[ "${ALLSKY_DEBUG_LEVEL}" -ge 4 ] && echo "${ME}: Resizing upload file '${FILE_TO_UPLOAD}' to ${RESIZE_UPLOADS_SIZE}"
-		convert "${WORKING_DIR}/${FULL_FILENAME}" -resize "${RESIZE_UPLOADS_SIZE}" -gravity East -chop 2x0 "${FILE_TO_UPLOAD}"
+		convert "${IMAGE_TO_USE}" -resize "${RESIZE_UPLOADS_SIZE}" -gravity East -chop 2x0 "${FILE_TO_UPLOAD}"
 		if [ $? -ne 0 ] ; then
 			echo -e "${YELLOW}*** ${ME}: WARNING: RESIZE_UPLOADS failed; continuing with larger image.${NC}"
 			# We don't know the state of $FILE_TO_UPLOAD so use the larger file.
-			FILE_TO_UPLOAD="${WORKING_DIR}/${FULL_FILENAME}"
+			FILE_TO_UPLOAD="${IMAGE_TO_USE}"
 		fi
 	else
-		FILE_TO_UPLOAD="${WORKING_DIR}/${FULL_FILENAME}"
+		FILE_TO_UPLOAD="${IMAGE_TO_USE}"
 	fi
 
 	"${ALLSKY_SCRIPTS}/upload.sh" "${FILE_TO_UPLOAD}" "${IMAGE_DIR}" "${FULL_FILENAME}" "SaveImage"

--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -144,7 +144,7 @@ if [ "${DAYTIME_SAVE}" = "true" -o "${DAY_OR_NIGHT}" = "NIGHT" ] ; then
 	cp "${IMAGE_TO_USE}" "${FINAL_FILE}" || echo "*** ERROR: ${ME}: unable to copy ${IMAGE_TO_USE} ***"
 	IMAGE_TO_USE="${FINAL_FILE}"
 fi
-cp "${IMAGE_TO_USE}" "${WORKING_DIR}/${FULL_FILENAME}"	# Websites look for $FULL_FILENAME
+mv "${IMAGE_TO_USE}" "${WORKING_DIR}/${FULL_FILENAME}"	# Websites look for $FULL_FILENAME
 
 # If upload is true, optionally create a smaller version of the image; either way, upload it
 if [ "${UPLOAD_IMG}" = "true" ] ; then
@@ -180,22 +180,19 @@ if [ "${UPLOAD_IMG}" = "true" ] ; then
 		# Put the copy in ${WORKING_DIR}.
 		FILE_TO_UPLOAD="${WORKING_DIR}/resize-${IMAGE_NAME}"
 		[ "${ALLSKY_DEBUG_LEVEL}" -ge 4 ] && echo "${ME}: Resizing upload file '${FILE_TO_UPLOAD}' to ${RESIZE_UPLOADS_SIZE}"
-		convert "${IMAGE_TO_USE}" -resize "${RESIZE_UPLOADS_SIZE}" -gravity East -chop 2x0 "${FILE_TO_UPLOAD}"
+		convert "${WORKING_DIR}/${FULL_FILENAME}" -resize "${RESIZE_UPLOADS_SIZE}" -gravity East -chop 2x0 "${FILE_TO_UPLOAD}"
 		if [ $? -ne 0 ] ; then
 			echo -e "${YELLOW}*** ${ME}: WARNING: RESIZE_UPLOADS failed; continuing with larger image.${NC}"
 			# We don't know the state of $FILE_TO_UPLOAD so use the larger file.
-			FILE_TO_UPLOAD="${IMAGE_TO_USE}"
+			FILE_TO_UPLOAD="${WORKING_DIR}/${FULL_FILENAME}"
 		fi
 	else
-		FILE_TO_UPLOAD="${IMAGE_TO_USE}"
+		FILE_TO_UPLOAD="${WORKING_DIR}/${FULL_FILENAME}"
 	fi
 
 	"${ALLSKY_SCRIPTS}/upload.sh" "${FILE_TO_UPLOAD}" "${IMAGE_DIR}" "${FULL_FILENAME}" "SaveImage"
 
 	[ "${RESIZE_UPLOADS}" = "true" ] && rm -f "${FILE_TO_UPLOAD}"	# was a temporary file
 fi
-
-# If it's daytime and we didn't save the image, delete it.
-[ "${DAYTIME_SAVE}" = "false" -a "${DAY_OR_NIGHT}" = "DAY" ] && rm -f "${IMAGE_TO_USE}"
 
 exit 0

--- a/src/Makefile
+++ b/src/Makefile
@@ -107,11 +107,15 @@ ifeq (,$(OPENCV))
 endif
 .PHONY : check_deps
 
-
-sunwait:
+patchsunwait:
 	@echo `date +%F\ %R:%S` Initializing sunwait submodule...
 	@git submodule init
 	@git submodule update
+	@echo `date +%F\ %R:%s` Patching sunwait compile warnings...
+	@patch -p1 -d sunwait-src/ < sunwait.patch
+	@touch patchsunwait
+
+sunwait: patchsunwait
 	@echo `date +%F\ %R:%S` Building sunwait...
 	@$(MAKE) -C sunwait-src
 	@cp sunwait-src/sunwait .

--- a/src/sunwait.patch
+++ b/src/sunwait.patch
@@ -1,0 +1,34 @@
+diff --git a/sunriset.cpp b/sunriset.cpp
+index ed6ee0b..f7f7974 100755
+--- a/sunriset.cpp
++++ b/sunriset.cpp
+@@ -148,7 +148,7 @@ void sunpos (const double d, double *lon, double *r)
+ void sun_RA_dec (const double d, double *RA, double *dec, double *r)
+ {
+   double lon, obl_ecl;
+-  double xs, ys, zs;
++  double xs, ys;
+   double xe, ye, ze;
+   
+   /* Compute Sun's ecliptical coordinates */
+@@ -157,7 +157,6 @@ void sun_RA_dec (const double d, double *RA, double *dec, double *r)
+   /* Compute ecliptic rectangular coordinates */
+   xs = *r * cosd(lon);
+   ys = *r * sind(lon);
+-  zs = 0; /* because the Sun is always in the ecliptic plane! */
+ 
+   /* Compute obliquity of ecliptic (inclination of Earth's axis) */
+   obl_ecl = 23.4393 - 3.563E-7 * d;
+diff --git a/sunwait.cpp b/sunwait.cpp
+index 7e43bc9..8ff6429 100755
+--- a/sunwait.cpp
++++ b/sunwait.cpp
+@@ -662,7 +662,7 @@ int main (int argc, char *argv[])
+     if (pRun->debug == ONOFF_ON) printf ("Debug: argv[%d]: >%s<\n", i, arg);
+ 
+     // Strip any hyphen from arguments, but not negative signs of numbers
+-    if (arg[0] == '-' && arg[1] != '\0' && !isdigit(arg[1])) *arg++;
++    if (arg[0] == '-' && arg[1] != '\0' && !isdigit(arg[1])) memmove(arg, arg + 1, sizeof arg - 1);
+ 
+     // Normal help or version info
+          if   (!strcmp (arg, "v")             ||


### PR DESCRIPTION
Upstream PRs [sunwait#24](https://github.com/risacher/sunwait/pull/24) and [sunwait#29](https://github.com/risacher/sunwait/pull/29) have sat for 30+ days with no action.  Patching here to clean up our compile messages.