### PR TITLE
config.sh.repo: allow users to specify fan data

### DIFF
--- a/config_repo/config.sh.repo
+++ b/config_repo/config.sh.repo
@@ -157,6 +157,11 @@ DAYTIME_CAPTURE="true"
 # Will only save daytime images if DAYTIME_CAPTURE="true".
 DAYTIME_SAVE="false"
 
+# If you have a fan in your Allsky camera enclosure that reports its speed,
+# set this to the full pathname of that file.
+# The file should include two numbers: the fan speed in RPM and the percent of maximum speed.
+FAN_DATA_FILE=""
+
 # The uhubctl command can reset the USB bus if the camera isn't found and you know it's there.
 # Allsky.sh uses this to try and fix "missing" cameras.
 # Specify the path to the command and the USB bus number (on a Pi 4, bus 1 is USB 2.0 and


### PR DESCRIPTION
This goes along with PR 91 in allsky-portal which uses this variable to display fan speed data on the System page.