### PR TITLE
shellcheck

### DIFF
--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -71,6 +71,15 @@ jobs:
                 #SC2012: Use find instead of ls to better handle non-alphanumeric filenames.
                 shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2164 -e SC2166 -e SC2181 -e SC2012
                 ;;
+              ./install.sh)
+                #SC2155: Declare and assign separately to avoid masking return values.
+                #SC2046: Quote this to prevent word splitting.
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2004: $/${} is unnecessary on arithmetic variables.
+                #SC2086: Double quote to prevent globbing and word splitting.
+                #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
+                shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2004 -e SC2086 -e SC2181
+                ;;
               *)
                 shellcheck $i
                 ;;

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -53,7 +53,12 @@ jobs:
                 #SC2155: Declare and assign separately to avoid masking return values.
                 #SC2046: Quote this to prevent word splitting.
                 #SC2086: Double quote to prevent globbing and word splitting.
-                shellcheck $i -e SC2155 -e SC2046 -e SC2086
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
+                #SC2002: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+                #SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
+                #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
+                shellcheck $i -e SC2155 -e SC2046 -e SC2086 -e SC1090 -e SC2164 -e SC2002 -e SC2166 -e SC2181
                 ;;
               *)
                 shellcheck $i

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -139,6 +139,10 @@ jobs:
                 #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
                 shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2086 -e SC2166 -e SC2219 -e SC2181
                 ;;
+              ./scripts/allsky_mfs.sh)
+                #SC2086: Double quote to prevent globbing and word splitting.
+                shellcheck $i -e SC2086
+                ;;
               *)
                 shellcheck $i
                 ;;

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -174,6 +174,12 @@ jobs:
                 #SC2086: Double quote to prevent globbing and word splitting.
                 shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2166 -e SC2086
                 ;;
+              ./scripts/darkSubtract.sh)
+                #SC2086: Double quote to prevent globbing and word splitting.
+                #SC2219: Instead of 'let expr', prefer (( expr )) .
+                #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
+                shellcheck $i -e SC2086 -e SC2219 -e SC2181
+                ;;
               *)
                 shellcheck $i
                 ;;
@@ -183,6 +189,7 @@ jobs:
             fi
           done
           if [ $err -ne 0 ]; then
+            echo '::echo::on'
             echo "::warning:: bash or shellcheck found problems in scripts. Please fix it or add some excludes (-e SC....) here in this file."
           fi
           exit $err

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -58,9 +58,10 @@ jobs:
                 #SC2002: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
                 #SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
                 #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
-                shellcheck $i -e SC2155 -e SC2046 -e SC2086 -e SC1090 -e SC2164 -e SC2002 -e SC2166 -e SC2181
+                ##SC2006: Use $(...) notation instead of legacy backticked `...`.
+                shellcheck $i -e SC2155 -e SC2046 -e SC2086 -e SC1090 -e SC2164 -e SC2002 -e SC2166 -e SC2181 -e SC2006
                 ;;
-              ./gui/install.sh)
+              next)
                 #SC2006: Use $(...) notation instead of legacy backticked `...`.
                 shellcheck $i -e SC2006 
                 ;;

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -127,7 +127,7 @@ jobs:
                 #SC2086: Double quote to prevent globbing and word splitting.
                 #SC2044: For loops over find output are fragile. Use find -exec or a while read loop.
                 #SC2004: $/${} is unnecessary on arithmetic variables.
-                shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2166 +e SC2086 -e SC2044 -e SC2004
+                shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2166 -e SC2086 -e SC2044 -e SC2004
                 ;;
               *)
                 shellcheck $i

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -44,7 +44,7 @@ jobs:
             if [ $? -ne 0 ]; then
               err=$((err + 1))
             fi
-            if [ "$i" = "variables.sh" ]; then
+            if [ "$i" = "./variables.sh" ]; then
               #SC2034: ON_TTY appears unused. Verify use (or export if used externally).
               shellcheck $i -e SC2034 
             else

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -58,12 +58,18 @@ jobs:
                 #SC2002: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
                 #SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
                 #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
-                ##SC2006: Use $(...) notation instead of legacy backticked `...`.
+                #SC2006: Use $(...) notation instead of legacy backticked `...`.
                 shellcheck $i -e SC2155 -e SC2046 -e SC2086 -e SC1090 -e SC2164 -e SC2002 -e SC2166 -e SC2181 -e SC2006
                 ;;
-              next)
-                #SC2006: Use $(...) notation instead of legacy backticked `...`.
-                shellcheck $i -e SC2006 
+              ./website/install.sh)
+                #SC2155: Declare and assign separately to avoid masking return values.
+                #SC2046: Quote this to prevent word splitting.
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
+                #SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
+                #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
+                #SC2012: Use find instead of ls to better handle non-alphanumeric filenames.
+                shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2164 -e SC2166 -e SC2181 -e SC2012
                 ;;
               *)
                 shellcheck $i

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -143,6 +143,15 @@ jobs:
                 #SC2086: Double quote to prevent globbing and word splitting.
                 shellcheck $i -e SC2086
                 ;;
+              ./scripts/saveImage.sh)
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2086: Double quote to prevent globbing and word splitting.
+                #SC2166: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
+                #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
+                #SC2166: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
+                #SC2219: Instead of 'let expr', prefer (( expr )) .
+                shellcheck $i -e SC1090 -e SC2086 -e SC2166 -e SC2181 -e SC2166 -e SC2219
+                ;;
               *)
                 shellcheck $i
                 ;;

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -60,6 +60,10 @@ jobs:
                 #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
                 shellcheck $i -e SC2155 -e SC2046 -e SC2086 -e SC1090 -e SC2164 -e SC2002 -e SC2166 -e SC2181
                 ;;
+              ./gui/install.sh)
+                #SC2006: Use $(...) notation instead of legacy backticked `...`.
+                shellcheck $i -e SC2006 
+                ;;
               *)
                 shellcheck $i
                 ;;

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -100,6 +100,17 @@ jobs:
                 #SC2162: read without -r will mangle backslashes.
                 shellcheck $i -e SC2034 -e SC2162
                 ;;
+              ./scripts/generate_notification_images.sh)
+                #SC2155: Declare and assign separately to avoid masking return values.
+                #SC2046: Quote this to prevent word splitting.
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2086: Double quote to prevent globbing and word splitting.
+                #SC2230: which is non-standard. Use builtin 'command -v' instead.
+                #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
+                #SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
+                #SC2016: Expressions don't expand in single quotes, use double quotes for that.
+                shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2086 -e SC2230 -e SC2181 -e SC2166 -e SC2016
+                ;;
               *)
                 shellcheck $i
                 ;;

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -44,7 +44,12 @@ jobs:
             if [ $? -ne 0 ]; then
               err=$((err + 1))
             fi
-            shellcheck $i 
+            if [ "$i" = "variables.sh" ]; then
+              #SC2034: ON_TTY appears unused. Verify use (or export if used externally).
+              shellcheck $i -e SC2034 
+            else
+              shellcheck $i
+            fi
             if [ $? -ne 0 ]; then
               err=$((err + 1))
             fi

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -44,12 +44,21 @@ jobs:
             if [ $? -ne 0 ]; then
               err=$((err + 1))
             fi
-            if [ "$i" = "./variables.sh" ]; then
-              #SC2034: ON_TTY appears unused. Verify use (or export if used externally).
-              shellcheck $i -e SC2034 
-            else
-              shellcheck $i
-            fi
+            case $i in
+              ./variables.sh)
+                #SC2034: ON_TTY appears unused. Verify use (or export if used externally).
+                shellcheck $i -e SC2034 
+                ;;
+              ./gui/install.sh)
+                #SC2155: Declare and assign separately to avoid masking return values.
+                #SC2046: Quote this to prevent word splitting.
+                #SC2086: Double quote to prevent globbing and word splitting.
+                shellcheck $i -e SC2155 -e SC2046 -e SC2086
+                ;;
+              *)
+                shellcheck $i
+                ;;
+            esac
             if [ $? -ne 0 ]; then
               err=$((err + 1))
             fi

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -200,8 +200,13 @@ jobs:
                 #SC2086: Double quote to prevent globbing and word splitting.
                 shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2166 -e SC2012 -e SC2188 -e SC2086
                 ;;
+              ./scripts/darkCapture.sh)
+                #SC2086: Double quote to prevent globbing and word splitting.
+                shellcheck $i -e SC2086
+                ;;
               *)
-                shellcheck $i
+                #SC2086: Double quote to prevent globbing and word splitting.
+                shellcheck $i -e SC2086
                 ;;
             esac
             if [ $? -ne 0 ]; then
@@ -209,7 +214,6 @@ jobs:
             fi
           done
           if [ $err -ne 0 ]; then
-            echo '::echo::on'
-            echo "::error:: bash or shellcheck found problems in scripts. Please fix it or add some excludes (-e SC....) here in this file."
+            echo "bash or shellcheck found problems in scripts. Please fix it or add some excludes (-e SC....) here in this file."
           fi
           exit $err

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -159,6 +159,12 @@ jobs:
                 #SC2086: Double quote to prevent globbing and word splitting.
                 shellcheck $i -e SC1090 -e SC2181 -e SC2166 -e SC2086
                 ;;
+              ./scripts/uploadForDay.sh)
+                #SC2155: Declare and assign separately to avoid masking return values.
+                #SC2046: Quote this to prevent word splitting.
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                shellcheck $i -e SC2155 -e SC2046 -e SC1090
+                ;;
               *)
                 shellcheck $i
                 ;;
@@ -168,6 +174,6 @@ jobs:
             fi
           done
           if [ $err -ne 0 ]; then
-            echo "shellcheck found problems in scripts. Please fix it or add some excludes (-e SC....) here in this file."
+            echo "::warning::bash or shellcheck found problems in scripts. Please fix it or add some excludes (-e SC....) here in this file."
           fi
           exit $err

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -190,6 +190,16 @@ jobs:
                 #SC2219: Instead of 'let expr', prefer (( expr )) .
                 shellcheck $i -e SC1090 -e SC2086 -e SC2166 -e SC2164 -e SC2188 -e SC2196 -e SC2219
                 ;;
+              ./scripts/timelapse.sh)
+                #SC2155: Declare and assign separately to avoid masking return values.
+                #SC2046: Quote this to prevent word splitting.
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
+                #SC2012: Use find instead of ls to better handle non-alphanumeric filenames.
+                #SC2188: This redirection doesn't have a command. Move to its command (or use 'true' as no-op).
+                #SC2086: Double quote to prevent globbing and word splitting.
+                shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2166 -e SC2012 -e SC2188 -e SC2086
+                ;;
               *)
                 shellcheck $i
                 ;;

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -80,6 +80,21 @@ jobs:
                 #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
                 shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2004 -e SC2086 -e SC2181
                 ;;
+              ./allsky.sh)
+                #SC2155: Declare and assign separately to avoid masking return values.
+                #SC2046: Quote this to prevent word splitting.
+                #SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2230: which is non-standard. Use builtin 'command -v' instead.
+                #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
+                #SC2086: Double quote to prevent globbing and word splitting.
+                #SC2206: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.
+                #SC2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting).
+                #SC2068: Double quote array expansions to avoid re-splitting elements.
+                #SC2006: Use $(...) notation instead of legacy backticked `...`.
+                #SC2166: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
+                shellcheck $i -e SC2155 -e SC2046 -e SC2164 -e SC1090 -e SC2230 -e SC2181 -e SC2086 -e SC2206 -e SC2207 -e SC2068 -e SC2006 -e SC2166
+                ;;
               *)
                 shellcheck $i
                 ;;

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -37,4 +37,17 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: check bash files
         run: |
-          err=0;for i in $(find . -name '*.sh'); do echo "$i"; bash -n $i; if [ $? -ne 0 ]; then err=$((err + 1)); fi; done; echo $err; exit $err
+          err=0
+          for i in $(find . -name '*.sh'); do
+            echo "$i"
+            bash -n $i
+            if [ $? -ne 0 ]; then
+              err=$((err + 1))
+            fi
+            shellcheck $i 
+            if [ $? -ne 0 ]; then
+              err=$((err + 1))
+            fi
+          done
+          echo $err
+          exit $err

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -152,6 +152,13 @@ jobs:
                 #SC2219: Instead of 'let expr', prefer (( expr )) .
                 shellcheck $i -e SC1090 -e SC2086 -e SC2166 -e SC2181 -e SC2166 -e SC2219
                 ;;
+              ./scripts/copy_notification_image.sh)
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
+                #SC2166: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
+                #SC2086: Double quote to prevent globbing and word splitting.
+                shellcheck $i -e SC1090 -e SC2181 -e SC2166 -e SC2086
+                ;;
               *)
                 shellcheck $i
                 ;;
@@ -160,5 +167,7 @@ jobs:
               err=$((err + 1))
             fi
           done
-          echo $err
+          if [ $err -ne 0 ]; then
+            echo "shellcheck found problems in scripts. Please fix it or add some excludes (-e SC....) here in this file."
+          fi
           exit $err

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -180,6 +180,16 @@ jobs:
                 #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
                 shellcheck $i -e SC2086 -e SC2219 -e SC2181
                 ;;
+              ./scripts/removeBadImages.sh)
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2086: Double quote to prevent globbing and word splitting.
+                #SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
+                #SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
+                #SC2188: This redirection doesn't have a command. Move to its command (or use 'true' as no-op).
+                #SC2196: egrep is non-standard and deprecated. Use grep -E instead.
+                #SC2219: Instead of 'let expr', prefer (( expr )) .
+                shellcheck $i -e SC1090 -e SC2086 -e SC2166 -e SC2164 -e SC2188 -e SC2196 -e SC2219
+                ;;
               *)
                 shellcheck $i
                 ;;
@@ -190,6 +200,6 @@ jobs:
           done
           if [ $err -ne 0 ]; then
             echo '::echo::on'
-            echo "::warning:: bash or shellcheck found problems in scripts. Please fix it or add some excludes (-e SC....) here in this file."
+            echo "::error:: bash or shellcheck found problems in scripts. Please fix it or add some excludes (-e SC....) here in this file."
           fi
           exit $err

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -95,6 +95,11 @@ jobs:
                 #SC2166: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
                 shellcheck $i -e SC2155 -e SC2046 -e SC2164 -e SC1090 -e SC2230 -e SC2181 -e SC2086 -e SC2206 -e SC2207 -e SC2068 -e SC2006 -e SC2166
                 ;;
+              ./uninstall.sh)
+                #SC2034: GREEN appears unused. Verify use (or export if used externally).
+                #SC2162: read without -r will mangle backslashes.
+                shellcheck $i -e SC2034 -e SC2162
+                ;;
               *)
                 shellcheck $i
                 ;;

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -129,6 +129,15 @@ jobs:
                 #SC2004: $/${} is unnecessary on arithmetic variables.
                 shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2166 -e SC2086 -e SC2044 -e SC2004
                 ;;
+              ./scripts/generateForDay.sh)
+                #SC2155: Declare and assign separately to avoid masking return values.
+                #SC2046: Quote this to prevent word splitting.
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2086: Double quote to prevent globbing and word splitting.
+                #SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
+                #SC2219: Instead of 'let expr', prefer (( expr )) .
+                shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2086 -e SC2166 -e SC2219
+                ;;
               *)
                 shellcheck $i
                 ;;

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -119,6 +119,16 @@ jobs:
                 #SC1083: This { is literal. Check expression (missing ;/\n?) or quote it.
                 shellcheck $i -e SC1090 -e SC2086 -e SC2166 -e SC2154 -e SC1083
                 ;;
+              ./scripts/endOfNight.sh)
+                #SC2155: Declare and assign separately to avoid masking return values.
+                #SC2046: Quote this to prevent word splitting.
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
+                #SC2086: Double quote to prevent globbing and word splitting.
+                #SC2044: For loops over find output are fragile. Use find -exec or a while read loop.
+                #SC2004: $/${} is unnecessary on arithmetic variables.
+                shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2166 +e SC2086 -e SC2044 -e SC2004
+                ;;
               *)
                 shellcheck $i
                 ;;

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -136,7 +136,8 @@ jobs:
                 #SC2086: Double quote to prevent globbing and word splitting.
                 #SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
                 #SC2219: Instead of 'let expr', prefer (( expr )) .
-                shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2086 -e SC2166 -e SC2219
+                #SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
+                shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2086 -e SC2166 -e SC2219 -e SC2181
                 ;;
               *)
                 shellcheck $i

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -37,6 +37,7 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: check bash files
         run: |
+          # check bash files (bash -n, shellcheck)
           err=0
           for i in $(find . -name '*.sh'); do
             echo "$i"
@@ -165,6 +166,14 @@ jobs:
                 #SC1090: Can't follow non-constant source. Use a directive to specify location.
                 shellcheck $i -e SC2155 -e SC2046 -e SC1090
                 ;;
+              ./scripts/upload.sh)
+                #SC2155: Declare and assign separately to avoid masking return values.
+                #SC2046: Quote this to prevent word splitting.
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2166: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
+                #SC2086: Double quote to prevent globbing and word splitting.
+                shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2166 -e SC2086
+                ;;
               *)
                 shellcheck $i
                 ;;
@@ -174,6 +183,6 @@ jobs:
             fi
           done
           if [ $err -ne 0 ]; then
-            echo "::warning::bash or shellcheck found problems in scripts. Please fix it or add some excludes (-e SC....) here in this file."
+            echo "::warning:: bash or shellcheck found problems in scripts. Please fix it or add some excludes (-e SC....) here in this file."
           fi
           exit $err

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -111,6 +111,14 @@ jobs:
                 #SC2016: Expressions don't expand in single quotes, use double quotes for that.
                 shellcheck $i -e SC2155 -e SC2046 -e SC1090 -e SC2086 -e SC2230 -e SC2181 -e SC2166 -e SC2016
                 ;;
+              ./scripts/postData.sh)
+                #SC1090: Can't follow non-constant source. Use a directive to specify location.
+                #SC2086: Double quote to prevent globbing and word splitting.
+                #SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
+                #SC2154: sunriset_hhmm is referenced but not assigned (did you mean 'sunrise_hhmm'?).
+                #SC1083: This { is literal. Check expression (missing ;/\n?) or quote it.
+                shellcheck $i -e SC1090 -e SC2086 -e SC2166 -e SC2154 -e SC1083
+                ;;
               *)
                 shellcheck $i
                 ;;


### PR DESCRIPTION
There are many functionally important bash files in the system.
Therefore, special attention should be paid to syntax and coding guidelines.
I'm not very familiar with the bash specifics, so it would be particularly important to me to check it with external tools (experts).

For this I found bash -h and shellcheck.

Shellcheck is very precise, so I excluded all existing warnings at the beginning.
Please check, there may be potential errors

(please use squash to merge the PR)