### PR TITLE
Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+documentation/*
 images/*
 config.sh
 darks/*

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,6 @@
+# Allsky  Documentation
+This directory contains files and images used in Allsky documentation and Wiki pages. In most cases these files will be linked into other pages.
+
+Keeping the files in this directory eliminates the need to keep them in an inividual's personal website.
+
+These files should not be included when a user grabs the Allsky Git package.


### PR DESCRIPTION
A location to store documentation and images that are linked into the Allsky README.md file, the Wiki, and Discussions.
Putting the files here eliminates the need to store them in an individual's personal website.

Ideally the "Documentation" directory would NOT be copied to a user's Pi when they grabbed the Allsky package.