### PR TITLE
copy_notification_images.sh: expire time

### DIFF
--- a/scripts/copy_notification_image.sh
+++ b/scripts/copy_notification_image.sh
@@ -44,14 +44,11 @@ if [ "${NOTIFICATION_TYPE}" = "custom" ]; then
 		usage_and_exit 1
 	fi
 
-	# Create a custom message, which is created in $PWD so change to the directory we want it in.
-	(
-		cd "${ALLSKY_TMP}"
-		# Extensions ($10) will normally be null since the invoker may not know what to use.
-		"${ALLSKY_SCRIPTS}/generate_notification_images.sh" "${NOTIFICATION_TYPE}" \
-			"${2}" "${3}" "${4}" "${5}" "${6}" \
-			 "${7}" "${8}" "${9}" "${10:-${EXTENSION}}" "${11}" "${12}"
-	)
+	# Create a custom message.
+	# Extensions ($10) will normally be null since the invoker may not know what to use.
+	"${ALLSKY_SCRIPTS}/generate_notification_images.sh" --directory "${ALLSKY_TMP}" "${NOTIFICATION_TYPE}" \
+		"${2}" "${3}" "${4}" "${5}" "${6}" \
+		"${7}" "${8}" "${9}" "${10:-${EXTENSION}}" "${11}" "${12}"
 	[ $? -ne 0 ] && exit 2
 	NOTIFICATION_FILE="${ALLSKY_TMP}/${NOTIFICATION_TYPE}.${EXTENSION}"
 else

--- a/scripts/copy_notification_image.sh
+++ b/scripts/copy_notification_image.sh
@@ -20,6 +20,7 @@ if [ ! -e "${NOTIFICATION_FILE}" ] ; then
 fi
 
 # Optional argument specifying when the ALLSKY_NOTIFICATION_LOG should expire.
+# If it's 0, then force the use of this notification.
 EXPIRES_IN_SECONDS="${2:-5}"	# default of 5 seconds
 
 # If a notification image was "recently" posted, don't post this one.
@@ -28,7 +29,7 @@ EXPIRES_IN_SECONDS="${2:-5}"	# default of 5 seconds
 # it's given a timestamp of NOW + $EXPIRES_IN_SECONDS.
 # We will APPEND to the file so we have a record of all notifications since Allsky started.
 
-if [ -f "${ALLSKY_NOTIFICATION_LOG}" ]; then
+if [ -f "${ALLSKY_NOTIFICATION_LOG}" ] && [ ${EXPIRES_IN_SECONDS} -ne 0 ]; then
 	# TODO: there has to be a better way to compare the time of a file??
 	NOW=$(date +'%Y%m%d%H%M%S')
 	FILE_TIME=$(ls -l --time-style="+%Y%m%d%H%M%S" ${ALLSKY_NOTIFICATION_LOG} | awk '{ print $6 }')

--- a/scripts/copy_notification_image.sh
+++ b/scripts/copy_notification_image.sh
@@ -89,6 +89,10 @@ else
 	# Don't overwrite notification images so create a temporary copy and use that.
 	CURRENT_IMAGE="${CAPTURE_SAVE_DIR}/notification-${FULL_FILENAME}"
 	cp "${NOTIFICATION_FILE}" "${CURRENT_IMAGE}"
+	if [ $? -ne 0 ]; then
+		echo -e "${RED}*** ${ME}: ERROR: copy of '${NOTIFICATION_FILE}' to '${CURRENT_IMAGE}' failed!${NC}"
+		exit 3
+	fi
 fi
 
 # Resize the image if required

--- a/scripts/copy_notification_image.sh
+++ b/scripts/copy_notification_image.sh
@@ -8,13 +8,13 @@ source "${ALLSKY_CONFIG}/ftp-settings.sh"
 
 NOTIFICATIONFILE="$1"	# filename, minus the extension, since the extension may vary
 if [ "$1" = "" ] ; then
-	echo "${RED}*** ${ME}: ERROR: no file specified.${NC}" >&2
+	echo -e "${RED}*** ${ME}: ERROR: no file specified.${NC}" >&2
 	exit 1
 fi
 
 NOTIFICATIONFILE="${ALLSKY_NOTIFICATION_IMAGES}/${NOTIFICATIONFILE}.${EXTENSION}"
 if [ ! -e "${NOTIFICATIONFILE}" ] ; then
-	echo "${RED}*** ${ME}: ERROR: File '${NOTIFICATIONFILE}' does not exist or is empty!${NC}" >&2
+	echo -e "${RED}*** ${ME}: ERROR: File '${NOTIFICATIONFILE}' does not exist or is empty!${NC}" >&2
 	exit 2
 fi
 
@@ -26,7 +26,7 @@ cp "${NOTIFICATIONFILE}" "${CURRENT_IMAGE}"
 if [ "${IMG_RESIZE}" = "true" ]; then
 	convert "${CURRENT_IMAGE}" -resize "${IMG_WIDTH}x${IMG_HEIGHT}" "${CURRENT_IMAGE}"
 	if [ $? -ne 0 ] ; then
-		echo "${RED}*** ${ME}: ERROR: IMG_RESIZE failed${NC}"
+		echo -e "${RED}*** ${ME}: ERROR: IMG_RESIZE failed${NC}"
 		exit 3
 	fi
 fi
@@ -46,7 +46,7 @@ if [ "${DAYTIME_SAVE}" = "true" -a "${IMG_CREATE_THUMBNAILS}" = "true" ] ; then
 
 	convert "${CURRENT_IMAGE}" -resize "${THUMBNAIL_SIZE_X}x${THUMBNAIL_SIZE_Y}" "${THUMB}"
 	if [ $? -ne 0 ] ; then
-		echo "${YELLOW}*** ${ME}: WARNING: THUMBNAIL resize failed; continuing.${NC}"
+		echo -e "${YELLOW}*** ${ME}: WARNING: THUMBNAIL resize failed; continuing.${NC}"
 	fi
 fi
 
@@ -62,7 +62,7 @@ if [ "${UPLOAD_IMG}" = "true" ] ; then
 		cp "${FINAL_IMAGE}" "${TEMP_FILE}"  # create temporary copy to resize
 		convert "${TEMP_FILE}" -resize "${RESIZE_UPLOADS_SIZE}" -gravity East -chop 2x0 "${TEMP_FILE}"
 		if [ $? -ne 0 ] ; then
-			echo "${RED}*** ${ME}: ERROR: RESIZE_UPLOADS failed${NC}"
+			echo -e "${RED}*** ${ME}: ERROR: RESIZE_UPLOADS failed${NC}"
 			# Leave temporary file for possible debugging.
 			exit 4
 		fi
@@ -73,7 +73,7 @@ if [ "${UPLOAD_IMG}" = "true" ] ; then
 	fi
 
 	# We're actually uploading $UPLOAD_FILE, but show $NOTIFICATIONFILE in the message since it's more descriptive.
-	echo "${ME}: Uploading $(basename "${NOTIFICATIONFILE}")"
+	echo -e "${ME}: Uploading $(basename "${NOTIFICATIONFILE}")"
 	"${ALLSKY_SCRIPTS}/upload.sh" --silent "${UPLOAD_FILE}" "${IMAGE_DIR}" "${FULL_FILENAME}" "NotificationImage"
 	RET=$?
 

--- a/scripts/copy_notification_image.sh
+++ b/scripts/copy_notification_image.sh
@@ -61,16 +61,14 @@ fi
 
 # If a notification image was "recently" posted, don't post this one.
 # We'll look at the timestamp of $ALLSKY_NOTIFICATION_LOG (defined in variables.sh) and if it's
-# in the future we'll skip the current notification. When the file is updated below.
+# in the future we'll skip the current notification. When the file is updated below,
 # it's given a timestamp of NOW + $EXPIRES_IN_SECONDS.
 # We will APPEND to the file so we have a record of all notifications since Allsky started.
 
 if [ "${NOTIFICATION_TYPE}" != "custom" ] && [ -f "${ALLSKY_NOTIFICATION_LOG}" ] && [ ${EXPIRES_IN_SECONDS} -ne 0 ]; then
-	# TODO: there has to be a better way to compare the time of a file??
-	NOW=$(date +'%Y%m%d%H%M%S')
-	FILE_TIME=$(ls -l --time-style="+%Y%m%d%H%M%S" ${ALLSKY_NOTIFICATION_LOG} | awk '{ print $6 }')
-
-	if [ ${FILE_TIME} -gt ${NOW} ]; then
+	NOW=$(date +'%Y-%m-%d %H:%M:%S')
+	RESULTS="$(find "${ALLSKY_NOTIFICATION_LOG}" -newermt "${NOW}" -print)"
+	if [ -n "${RESULTS}" ]; then	# the file is in the future
 		if [ ${ALLSKY_DEBUG_LEVEL} -ge 3 ]; then
 			# File contains:	Notification_type,expires_in_seconds,expiration_time
 			RECENT_NOTIFICATION=$(tail -1 "${ALLSKY_NOTIFICATION_LOG}")
@@ -89,10 +87,6 @@ else
 	# Don't overwrite notification images so create a temporary copy and use that.
 	CURRENT_IMAGE="${CAPTURE_SAVE_DIR}/notification-${FULL_FILENAME}"
 	cp "${NOTIFICATION_FILE}" "${CURRENT_IMAGE}"
-	if [ $? -ne 0 ]; then
-		echo -e "${RED}*** ${ME}: ERROR: copy of '${NOTIFICATION_FILE}' to '${CURRENT_IMAGE}' failed!${NC}"
-		exit 3
-	fi
 fi
 
 # Resize the image if required

--- a/variables.sh
+++ b/variables.sh
@@ -50,6 +50,9 @@ if [ "${ALLSKY_VARIABLE_SET}" = "" ]; then
 
 	# Holds all the notification images.
 	ALLSKY_NOTIFICATION_IMAGES="${ALLSKY_NOTIFICATION_IMAGES:-${ALLSKY_HOME}/notification_images}"
+	# Holds log of notifications displayed during this session.
+	ALLSKY_NOTIFICATION_LOG="${ALLSKY_TMP}/last_notification.txt"
+
 
 	# Holds all the dark frames.
 	ALLSKY_DARKS="${ALLSKY_DARKS:-${ALLSKY_HOME}/darks}"

--- a/variables.sh
+++ b/variables.sh
@@ -51,8 +51,7 @@ if [ "${ALLSKY_VARIABLE_SET}" = "" ]; then
 	# Holds all the notification images.
 	ALLSKY_NOTIFICATION_IMAGES="${ALLSKY_NOTIFICATION_IMAGES:-${ALLSKY_HOME}/notification_images}"
 	# Holds log of notifications displayed during this session.
-	ALLSKY_NOTIFICATION_LOG="${ALLSKY_TMP}/last_notification.txt"
-
+	ALLSKY_NOTIFICATION_LOG="${ALLSKY_TMP}/notification_log.txt"
 
 	# Holds all the dark frames.
 	ALLSKY_DARKS="${ALLSKY_DARKS:-${ALLSKY_HOME}/darks}"


### PR DESCRIPTION
This PR introduces the concept of notification image expiration times, the default being 5 seconds.
If a notification was displayed in the last 5 seconds a new one is to be displayed, don't display it.
For example, if we just displayed "Restarting Allsky" then don't display a "Allsky is starting up" notification because the user likely won't see the "Restarting Allsky" message.

This PR also keeps a log of the notification images displayed.  A future PR will have allsky.sh truncate the log so it only lasts through the current Allsky session.  This will be more important in the future when the capture programs can be sent a signal to re-read the settings, since that will be done in the same session.

This PR also allows a program calling copy_notification_images.sh to pass in argument to create a custom notification message. 
The capture programs and allsky.sh will be modified in a future PR to do this when, for example, the cause of an error is known - it can be displayed in the notification message to better alert the user as to what the problem is.  This should aid in support.