### PR TITLE
Create reload.sh

### DIFF
--- a/config_repo/allsky.service.repo
+++ b/config_repo/allsky.service.repo
@@ -10,8 +10,8 @@ Restart=on-success
 RestartSec=5
 ; exit status 100 means fatal error the user needs to fix, so don't restart
 RestartPreventExitStatus=100
-; XXX RestartKillSignal is not recognized by systemd despite it being described in the documentation.
-; Not sure why, so use ExecReload instead.
+; XXX RestartKillSignal is not recognized by the systemd that comes with Buster (not sure about Bullseye),
+; so use ExecReload instead.
 ; RestartKillSignal=SIGUSR1
 ExecReload=/home/pi/allsky/scripts/reload.sh $MAINPID
 

--- a/config_repo/allsky.service.repo
+++ b/config_repo/allsky.service.repo
@@ -6,8 +6,14 @@ After=multi-user.target
 User=pi
 ExecStart=/home/pi/allsky/allsky.sh
 SyslogFacility=local5
-Restart=always
+Restart=on-success
 RestartSec=5
+; exit status 100 means fatal error the user needs to fix, so don't restart
+RestartPreventExitStatus=100
+; XXX RestartKillSignal is not recognized by systemd despite it being described in the documentation.
+; Not sure why, so use ExecReload instead.
+; RestartKillSignal=SIGUSR1
+ExecReload=/home/pi/allsky/scripts/reload.sh $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# ${1} is allsky.sh.  Send a signal to any child process.
+PID=${1}
+if [ -z "${PID}" ]; then
+	echo "*** ERROR on reload - no PID specified ***"
+	exit 1
+fi
+
+TO_SEND_SIGNAL=$(ps --ppid ${PID} -o pid | grep -v PID)
+if [ -z "${TO_SEND_SIGNAL}" ]; then
+	echo "*** ERROR on reload - cannot find any children of PID ${PID} ***"
+	exit 2
+fi
+
+echo "TO_SEND_SIGNAL=$TO_SEND_SIGNAL"
+kill -USR1 $TO_SEND_SIGNAL

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 
-# ${1} is allsky.sh.  Send a signal to any child process.
+# ${1} is allsky.sh's process ID (PID).  Send a signal to any child process
+# which should normally just be the "capture" program.
 PID=${1}
 if [ -z "${PID}" ]; then
-	echo "*** ERROR on reload - no PID specified ***"
+	echo "*** ERROR in reload.sh: no PID specified on command line ***"
 	exit 1
 fi
 
 TO_SEND_SIGNAL=$(ps --ppid ${PID} -o pid | grep -v PID)
 if [ -z "${TO_SEND_SIGNAL}" ]; then
-	echo "*** ERROR on reload - cannot find any children of PID ${PID} ***"
+	echo "*** ERROR in reload.sh: cannot find any children of PID ${PID} ***"
 	exit 2
 fi
 
-echo "TO_SEND_SIGNAL=$TO_SEND_SIGNAL"
+echo "$0: Sending SIGUSR1 to PID $TO_SEND_SIGNAL"
 kill -USR1 $TO_SEND_SIGNAL


### PR DESCRIPTION
This PR creates scripts/reload.sh which sends a SIGUSR1 signal to the children of the "allsky.sh" program, which will usually be the capture or capture_RPiHQ command.  They then display an "Allsky is restarting" message, then exit, which causes the service to be restarted.  This is nicer and more informative than having an "Allsky is not running" message followed by "Allsky is starting".

The modified "allsky.service" file calls reload.sh when `sudo systemctl reload allsky` is executed.

A future PR will have the WebUI invoke reload when settings change, rather than doing a "restart", which causes the two messages to be displayed.  Unfortunately the version of systemctl that comes with Buster doesn't support sending a different signal when "status" is executed.  If it did, reload.sh wouldn't be needed (although the updated "allsky.service" file would be).