### PR TITLE
testing: change priority

### DIFF
--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -22,17 +22,6 @@ jobs:
         run: |
           ls -la
           uptime
-          echo make
-
-      # Runs a set of commands using the runners shell
-      - name: make deps
-        run: |
-          sudo make deps
-
-      # Runs a set of commands using the runners shell
-      - name: make all
-        run: |
-          sudo make all
 
       # Runs a set of commands using the runners shell
       - name: check bash files
@@ -219,3 +208,14 @@ jobs:
             echo "bash or shellcheck found problems in scripts. Please fix it or add some excludes (-e SC....) here in this file."
           fi
           exit $err
+
+      # Runs a set of commands using the runners shell
+      - name: make deps
+        run: |
+          sudo make deps
+
+      # Info: depends an step "make deps"
+      - name: make all
+        run: |
+          sudo make all
+


### PR DESCRIPTION
Bash/shellcheck takes less time and is independent from the other steps. Therefore, this step is now prioritised.