### PR TITLE
Allsky.sh improvements

### DIFF
--- a/allsky.sh
+++ b/allsky.sh
@@ -37,13 +37,12 @@ fi
 # Check for a new variable in config.sh that wasn't in prior versions.
 # If not set to something (even "") then it wasn't found and force the user to upgrade config.sh
 source "${ALLSKY_CONFIG}/config.sh"
-if [ ! -v FAN_DATA_FILE ]; then	# FAN_DATA_FILE added after version 0.8.3.
-	echo "${RED}*** ERROR: old version of ${ALLSKY_CONFIG}/config.sh detected.${NC}"
+if [ ! -v WEBUI_DATA_FILES ]; then	# WEBUI_DATA_FILES added after version 0.8.3.
+	echo -e "${RED}*** FATAL ERROR: old version of ${ALLSKY_CONFIG}/config.sh detected.${NC}"
 	echo "Please move your current config.sh file to config.sh-OLD, then place the newest one"
 	echo "from https://github.com/thomasjacquin/allsky in ${ALLSKY_CONFIG} and"
-	echo "manually copy your data from the old file to the new one.".
-	USE_NOTIFICATION_IMAGES=1	# forces displaying notification
-	doExit ${EXIT_ERROR_STOP} "Error"
+	echo "manually copy your data from the old file to the new one."
+	doExit ${EXIT_ERROR_STOP} "Error" "${ERROR_MSG_PREFIX}\n$(basename ${ALLSKY_CONFIG})/config.sh\nis an old version.  See\n/var/log/allsky.log"
 fi
 USE_NOTIFICATION_IMAGES=$(jq -r '.notificationimages' "$CAMERA_SETTINGS")
 

--- a/allsky.sh
+++ b/allsky.sh
@@ -231,6 +231,7 @@ if [[ $CAMERA == "ZWO" ]]; then
 elif [[ $CAMERA == "RPiHQ" ]]; then
 	CAPTURE="capture_RPiHQ"
 fi
+rm -f "${ALLSKY_NOTIFICATION_LOG}"	# clear out any notificatons from prior runs.
 "${ALLSKY_HOME}/${CAPTURE}" "${ARGUMENTS[@]}"		# run the main program
 RETCODE=$?
 
@@ -279,7 +280,7 @@ if [ "${RETCODE}" -eq ${EXIT_RESET_USB} ]; then
 fi
 
 # RETCODE -ge ${EXIT_ERROR_STOP} means we should not restart until the user fixes the error.
-if [ "${RETCODE}" -ge ${EXIT_CODE_STOP} ]; then
+if [ "${RETCODE}" -ge ${EXIT_ERROR_STOP} ]; then
 	echo "***"
 	if [ ${ON_TTY} = "1" ]; then
 		echo "*** After fixing, restart allsky.sh. ***"
@@ -287,7 +288,7 @@ if [ "${RETCODE}" -ge ${EXIT_CODE_STOP} ]; then
 		echo "*** After fixing, restart the allsky service. ***"
 	fi
 	echo "***"
-	doExit ${EXIT_ERROR_STOP} "Error"
+	doExit ${EXIT_ERROR_STOP} "Error"	# Can't do a custom message since we don't know the problem
 fi
 
 # Some other error

--- a/allsky.sh
+++ b/allsky.sh
@@ -43,9 +43,8 @@ function doExit()
 
 source "${ALLSKY_HOME}/variables.sh"
 if [ -z "${ALLSKY_CONFIG}" ]; then
-	echo "${RED}*** ERROR: variables not set, can't continue!${NC}"
-	USE_NOTIFICATION_IMAGES=1	# forces displaying notification
-	doExit ${EXIT_ERROR_STOP} "Error"
+	echo -e "${RED}*** FATAL ERROR: variables not set, can't continue!${NC}"
+	doExit ${EXIT_ERROR_STOP} "Error" "${ERROR_MSG_PREFIX}\n$(basename ${ALLSKY_HOME})/variables.sh\nis corrupted!"
 fi
 
 # COMPATIBILITY CHECKS
@@ -62,8 +61,8 @@ fi
 USE_NOTIFICATION_IMAGES=$(jq -r '.notificationimages' "$CAMERA_SETTINGS")
 
 if [ -z "${CAMERA}" ]; then
-	echo "${RED}*** ERROR: CAMERA not set, can't continue!${NC}"
-	doExit ${EXIT_ERROR_STOP} "Error"
+	echo -e "${RED}*** FATAL ERROR: CAMERA not set, can't continue!${NC}"
+	doExit ${EXIT_ERROR_STOP} "Error" "${ERROR_MSG_PREFIX}\nCAMERA type\nnot specified in\n$(basename ${ALLSKY_CONFIG})/config.sh."
 fi
 
 # Make sure allsky.sh is not already running.
@@ -94,8 +93,8 @@ if [ "${CAMERA}" = "RPiHQ" ]; then
 		RET=$?
 	fi
 	if [ ${RET} -ne 0 ]; then
-		echo "${RED}*** ERROR: RPiHQ Camera not found. Exiting.${NC}" >&2
-		doExit ${EXIT_ERROR_STOP} "Error"
+		echo -e "${RED}*** FATAL ERROR: RPiHQ Camera not found.  Make sure it's enabled. Stopping.${NC}" >&2
+		doExit ${EXIT_ERROR_STOP} "Error" "${ERROR_MSG_PREFIX}\nRPiHQ Camera\nnot found!\nMake sure it's enabled."
 	fi
 
 elif [ "${CAMERA}" = "ZWO" ]; then


### PR DESCRIPTION
* Improve mechanism to determine if RPiHQ camera should use libcamera (new in Bullseye but can also be run on Buster), or the older raspistill.
* Rather than a generic "ERROR: See /var/log/allsky.log" message, produce messages like "*** ERROR ***    Allsky stopped!   ZWO camera not found".
* Only reset the USB bus twice on ASI_ERROR_TIMEOUT, then stop, rather than trying forever.
* Some minor changes.