### PR TITLE
lighttpd.conf: enable disabling buffer

### DIFF
--- a/gui/lighttpd.conf
+++ b/gui/lighttpd.conf
@@ -17,7 +17,9 @@ server.port                 = 80
 
 dir-listing.activate = "enable"
 
-$HTTP["url"] =~ "^/current" {
+$HTTP["url"] =~ "allsky/videos|allsky/startrails|allsky/keograms" {
+	server.stream-response-body = 1
+} else $HTTP["url"] =~ "^/current" {
   expire.url = ( "" => "access plus 0 seconds")
   setenv.add-response-header += (
         "Cache-Control" => "must-revalidate, proxy-revalidate, max-age=0"


### PR DESCRIPTION
This will be used by the Allsky website when creating thumbnails which take a while, to avoid having the user look at a blank screen for several seconds.