### PR TITLE
Switched from mac address to machine id

### DIFF
--- a/scripts/postToMap.sh
+++ b/scripts/postToMap.sh
@@ -28,7 +28,7 @@ IMAGE_URL=$(jq -r '.imageurl' "$CAMERA_SETTINGS")
 CAMERA=$(jq -r '.camera' "$CAMERA_SETTINGS")
 LENS=$(jq -r '.lens' "$CAMERA_SETTINGS")
 COMPUTER=$(jq -r '.computer' "$CAMERA_SETTINGS")
-MAC_ADDRESS="$(sudo cat /sys/class/net/"$(ip route show default | awk '/default/ {print $5}')"/address)"
+MACHINE_ID="$(cat /etc/machine-id)"
 
 generate_post_data()
 {
@@ -43,24 +43,24 @@ generate_post_data()
   "camera": "$CAMERA",
   "lens": "$LENS",
   "computer": "$COMPUTER",
-  "mac_address": "$MAC_ADDRESS"
+  "machine_id": "$MACHINE_ID"
 }
 EOF
 }
 
-# Extract last character of mac address and find its parity
-digit="${MAC_ADDRESS: -1}"
+# Extract last character of machine ID and find its parity
+digit="${MACHINE_ID: -1}"
 decimal=$(( 16#$digit ))
 parity="$(( decimal % 2 ))"
 
 # Only upload every other day to save on server bandwidth
 if  (( $(date +%d) % 2 == parity ))
 then
-   echo "Week day matches Mac Address ending - upload"
+   echo "Week day matches Machine ID ending - upload"
    curl -i \
    -H "Accept: application/json" \
    -H "Content-Type:application/json" \
    --data "$(generate_post_data)" "https://www.thomasjacquin.com/allsky-map/postToMap.php"
 else
-   echo "Week day doesn't match Mac Address ending - don't upload"
+   echo "Week day doesn't match Machine ID ending - don't upload"
 fi


### PR DESCRIPTION
The PR switches the unique ID from Mac Address to Machine ID.

This is to address the fact that in some cases, the RPi can have multiple interfaces enabled and there's a need to parse the output and select only one mac address. Furthermore, if the user switches from `wlan0` to `eth0`, they would have a different mac address.

The Machine ID documentation can be found here:  https://man7.org/linux/man-pages/man5/machine-id.5.html