### PR TITLE
lighttpd.conf: don't use compress modules

### DIFF
--- a/gui/lighttpd.conf
+++ b/gui/lighttpd.conf
@@ -28,6 +28,8 @@ $HTTP["url"] =~ "allsky/videos|allsky/startrails|allsky/keograms" {
 
 alias.url		    = ("/current/" => "/home/pi/allsky/")
 alias.url		    += ("/images/" => "/home/pi/allsky/images/")
+alias.url		    += ("/website/" => "/var/www/html/allsky/")
+
 # strict parsing and normalization of URL for consistency and security
 # https://redmine.lighttpd.net/projects/lighttpd/wiki/Server_http-parseoptsDetails
 # (might need to explicitly set "url-path-2f-decode" = "disable"

--- a/gui/lighttpd.conf
+++ b/gui/lighttpd.conf
@@ -50,8 +50,8 @@ index-file.names            = ( "index.php", "index.html" )
 url.access-deny             = ( "~", ".inc" )
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 
-compress.cache-dir          = "/var/cache/lighttpd/compress/"
-compress.filetype           = ( "application/javascript", "text/css", "text/html", "text/plain" )
+#compress.cache-dir          = "/var/cache/lighttpd/compress/"
+#compress.filetype           = ( "application/javascript", "text/css", "text/html", "text/plain" )
 
 #mimetype.assign             = (".css" => "text/css", )
 


### PR DESCRIPTION
When "mod_compress" was commented out in October 2021, the two lines in the file that use the "compress" module should have also been commented out.  Not doing so creates a couple entries in the error log.