### PR TITLE
Focus metric

### DIFF
--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -585,3 +585,18 @@ int doOverlay(cv::Mat image,
 
 	return(iYOffset);
 }
+
+// https://stackoverflow.com/questions/7765810/is-there-a-way-to-detect-if-an-image-is-blurry
+// https://drive.google.com/file/d/0B6UHr3GQEkQwYnlDY2dKNTdudjg/view?resourcekey=0-a73PvBnc3a2B5wztAV0QaA
+double get_focus_metric(cv::Mat img)
+{
+ 	cv::Mat lap;
+	cv::Laplacian(img, lap, CV_64F);
+
+	cv::Scalar mu, sigma;
+	cv::meanStdDev(lap, mu, sigma);
+
+	double focusMetric = sigma.val[0]*sigma.val[0];
+	Log(4, "  > Focus: %'f\n", focusMetric);
+	return(focusMetric);
+}

--- a/src/capture_RPiHQ.cpp
+++ b/src/capture_RPiHQ.cpp
@@ -598,10 +598,6 @@ const char *locale				= DEFAULT_LOCALE;
 			{
 				quality = atoi(argv[++i]);
 			}
-			else if (strcmp(argv[i], "-focus") == 0)
-			{
-				showFocus = getBoolean(argv[++i]);
-			}
 			else if (strcmp(argv[i], "-dayexposure") == 0)
 			{
 				dayExposure_us = atof(argv[++i]) * US_IN_MS;	// allow fractions
@@ -898,7 +894,7 @@ const char *locale				= DEFAULT_LOCALE;
 		printf("\n");
 		printf(" -preview							- Set to 1 to preview the captured images. Only works with a Desktop Environment\n");
 		printf(" -darkframe							- Set to 1 to grab dark frame and cover your camera\n");
-		printf(" -showTime								- Set to 1 to display the time on the image.\n");
+		printf(" -showTime							- Set to 1 to display the time on the image.\n");
 		printf(" -focus								- Set to 1 to display a focus metric on the image.\n");
 		printf(" -notificationimages				- Set to 1 to enable notification images, for example, 'Camera is off during day'.\n");
 		printf(" -debuglevel						- Default = 0. Set to 1,2 or 3 for more debugging information.\n");

--- a/src/include/allsky_common.h
+++ b/src/include/allsky_common.h
@@ -98,3 +98,4 @@ int doOverlay(cv::Mat,
 	int, int, int, int,
 	int[], int[], bool, int);
 bool getBoolean(const char *);
+double get_focus_metric(cv::Mat);

--- a/src/include/mode_RPiHQ_mean.h
+++ b/src/include/mode_RPiHQ_mean.h
@@ -38,4 +38,3 @@ struct modeMeanSetting {
 
 void RPiHQInit(bool autoExposure, int exposure_us, bool autoGain, double gain, raspistillSetting &currentRaspistillSetting, modeMeanSetting &currentModeMeanSetting);
 float RPiHQcalcMean(cv::Mat, int, double, raspistillSetting &, modeMeanSetting &);
-double get_focus_metric(cv::Mat);

--- a/src/mode_RPiHQ_mean.cpp
+++ b/src/mode_RPiHQ_mean.cpp
@@ -38,22 +38,6 @@ int dExposureChange = 0;
 bool createMaskHorizon = true;
 bool fastforward = false;
 
-// https://stackoverflow.com/questions/7765810/is-there-a-way-to-detect-if-an-image-is-blurry
-// https://drive.google.com/file/d/0B6UHr3GQEkQwYnlDY2dKNTdudjg/view?resourcekey=0-a73PvBnc3a2B5wztAV0QaA
-double get_focus_metric(cv::Mat img)
-{
- 	cv::Mat lap;
-	cv::Laplacian(img, lap, CV_64F);
-
-	cv::Scalar mu, sigma;
-	cv::meanStdDev(lap, mu, sigma);
-
-	double focusMetric = sigma.val[0]*sigma.val[0];
-	Log(4, "  > Focus: %'f\n", focusMetric);
-	return(focusMetric);
-}
-
-
 int calcExposureLevel (int exposure_us, double gain, modeMeanSetting &currentModeMeanSetting)
 {
 	return log(gain  * exposure_us/(double)US_IN_SEC) / log (2.0) * pow(currentModeMeanSetting.shuttersteps,2.0);


### PR DESCRIPTION
Allow ZWO cameras to call get_focus_metric() so they can display the focus metric like RPiHQ cameras do.
This required moving the function to allsky_common.cpp and moving forward definition of it to allsky_common.h.