### PR TITLE
Better msg about restarting

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -611,7 +611,10 @@ void closeUp(int e)
 
 void sig(int i)
 {
-	printf("XXXXXX == got %s %d in sig()\n", i == SIGUSR1 ? "SIGUSR1" : i == SIGHUP ? "SIGHUP" : "unknown signal", i);
+	if (i == SIGHUP)
+		Log(3, "Got signal to restart\n");
+	else
+		printf("XXXXXX == got %s %d in sig()\n", i == SIGUSR1 ? "SIGUSR1" : "unknown signal", i);
 	gotSignal = true;
 	closeUp(EXIT_RESTARTING);
 }

--- a/src/capture_RPiHQ.cpp
+++ b/src/capture_RPiHQ.cpp
@@ -109,7 +109,10 @@ void closeUp(int e)
 
 void sig(int i)
 {
-	printf("XXXXXX == got %s %d in sig()\n", i == SIGUSR1 ? "SIGUSR1" : i == SIGHUP ? "SIGHUP" : "unknown signal", i);
+	if (i == SIGHUP)
+		Log(3, "Got signal to restart\n");
+	else
+		printf("XXXXXX == got %s %d in sig()\n", i == SIGUSR1 ? "SIGUSR1" : "unknown signal", i);
 	bMain = false;
 	closeUp(EXIT_RESTARTING);
 }
@@ -840,7 +843,7 @@ const char *locale				= DEFAULT_LOCALE;
 			}
 		}
 	}
-	
+
 	if (setlocale(LC_NUMERIC, locale) == NULL)
 		printf("*** WARNING: Could not set locale to %s ***\n", locale);
 


### PR DESCRIPTION
SIGHUP is used to tell the capture programs to restart (eventually they will re-read configuration variables instead of actually restarting).
The prior Log() message when SIGHUP was received was temporary; this PR produces a better message.