### PR TITLE
postToMap.sh: fix bug with %d versus %e

### DIFF
--- a/scripts/postToMap.sh
+++ b/scripts/postToMap.sh
@@ -166,7 +166,7 @@ if [ "${UPLOAD}" = "false" ]; then
 	digit="${MACHINE_ID: -1}"
 	decimal=$(( 16#$digit ))
 	parity="$(( decimal % 2 ))"
-	(( $(date +%d) % 2 == parity )) && UPLOAD=true
+	(( $(date +%e) % 2 == parity )) && UPLOAD=true
 fi
 
 RETURN_CODE=0


### PR DESCRIPTION
* On the 8th or 9th of the month the check for day to upload fails since "date +%d" on the 8th of the month 8 returns "08".  When doing arithmetic, the shell treats a number that starts with "0" as octal and 08 and 09 are invalid octal numbers.  I had the exact same issue with the dark subtract script and wasn't able to find a good way around it.  Using "date +%e" returns "8" which is fine in shell arithmetic