### PR TITLE
Crop sanity checks

### DIFF
--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -140,6 +140,12 @@ if [ "${CROP_IMAGE}" = "true" ] ; then
 			ERROR_MSG="${ERROR_MSG}\n*** CROP_HEIGHT (${CROP_HEIGHT}) must be an even number."
 		fi
 	fi
+	if [[ "${CROP_OFFSET_X}" != +([-+0-9]) ]]; then
+		ERROR_MSG="${ERROR_MSG}\n*** CROP_OFFSET_X (${CROP_OFFSET_X}) must be a number."
+	fi
+	if [[ "${CROP_OFFSET_Y}" != +([-+0-9]) ]]; then
+		ERROR_MSG="${ERROR_MSG}\n*** CROP_OFFSET_Y (${CROP_OFFSET_Y}) must be a number."
+	fi
 
 	# Now for more intensive checks.
 	if [ -z "${ERROR_MSG}" ]; then

--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -122,32 +122,34 @@ if [ "${CROP_IMAGE}" = "true" ] ; then
 		fi
 		return 0
 	}
+	# shellcheck disable=SC2153
 	if check_value "CROP_WIDTH" "${CROP_WIDTH}" "width" "${RESOLUTION_X}"; then
-		if [ $(( ${CROP_WIDTH} % 2 )) = 1 ]; then
+		if [ $(( CROP_WIDTH % 2 )) = 1 ]; then
 			ERROR_MSG="${ERROR_MSG}\n*** CROP_WIDTH (${CROP_WIDTH}) must be an even number."
 		fi
 	fi
+	# shellcheck disable=SC2153
 	if check_value "CROP_HEIGHT" "${CROP_HEIGHT}" "height" "${RESOLUTION_Y}"; then
-		if [ $(( ${CROP_HEIGHT} % 2 )) = 1 ]; then
+		if [ $(( CROP_HEIGHT % 2 )) = 1 ]; then
 			ERROR_MSG="${ERROR_MSG}\n*** CROP_HEIGHT (${CROP_HEIGHT}) must be an even number."
 		fi
 	fi
 
 	# Now for more intensive checks.
 	if [ -z "${ERROR_MSG}" ]; then
-		typeset -i SENSOR_CENTER_X=$(( ${RESOLUTION_X} / 2 ))
-		typeset -i SENSOR_CENTER_Y=$(( ${RESOLUTION_Y} / 2 ))
-		typeset -i CROP_CENTER_ON_SENSOR_X=$(( ${SENSOR_CENTER_X} + ${CROP_OFFSET_X} ))
+		typeset -i SENSOR_CENTER_X=$(( RESOLUTION_X / 2 ))
+		typeset -i SENSOR_CENTER_Y=$(( RESOLUTION_Y / 2 ))
+		typeset -i CROP_CENTER_ON_SENSOR_X=$(( SENSOR_CENTER_X + CROP_OFFSET_X ))
 		# There appears to be a bug in "convert" with "-gravity Center"; the Y offset is only applied half.
 		# Should the division round up or down or truncate (current method)?
-		typeset -i CROP_CENTER_ON_SENSOR_Y=$(( ${SENSOR_CENTER_Y} + (${CROP_OFFSET_Y} / 2) ))
-		typeset -i HALF_CROP_WIDTH=$(( ${CROP_WIDTH} / 2 ))
-		typeset -i HALF_CROP_HEIGHT=$(( ${CROP_HEIGHT} / 2 ))
+		typeset -i CROP_CENTER_ON_SENSOR_Y=$(( SENSOR_CENTER_Y + (CROP_OFFSET_Y / 2) ))
+		typeset -i HALF_CROP_WIDTH=$(( CROP_WIDTH / 2 ))
+		typeset -i HALF_CROP_HEIGHT=$(( CROP_HEIGHT / 2 ))
 
-		typeset -i CROP_TOP=$(( ${CROP_CENTER_ON_SENSOR_Y} - ${HALF_CROP_HEIGHT} ))
-		typeset -i CROP_BOTTOM=$(( ${CROP_CENTER_ON_SENSOR_Y} + ${HALF_CROP_HEIGHT} ))
-		typeset -i CROP_LEFT=$(( ${CROP_CENTER_ON_SENSOR_X} - ${HALF_CROP_WIDTH} ))
-		typeset -i CROP_RIGHT=$(( ${CROP_CENTER_ON_SENSOR_X} + ${HALF_CROP_WIDTH} ))
+		typeset -i CROP_TOP=$(( CROP_CENTER_ON_SENSOR_Y - HALF_CROP_HEIGHT ))
+		typeset -i CROP_BOTTOM=$(( CROP_CENTER_ON_SENSOR_Y + HALF_CROP_HEIGHT ))
+		typeset -i CROP_LEFT=$(( CROP_CENTER_ON_SENSOR_X - HALF_CROP_WIDTH ))
+		typeset -i CROP_RIGHT=$(( CROP_CENTER_ON_SENSOR_X + HALF_CROP_WIDTH ))
 
 
 		if [ ${CROP_TOP} -lt 0 ]; then

--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -94,6 +94,27 @@ fi
 
 # Resize the image if required
 if [ "${IMG_RESIZE}" = "true" ] ; then
+	# Make sure we were given numbers.
+	ERROR_MSG=""
+	if [[ "${IMG_WIDTH}" != +([+0-9]) ]]; then		# no negative numbers allowed
+		ERROR_MSG="${ERROR_MSG}\n*** IMG_WIDTH (${IMG_WIDTH}) must be a number."
+	fi
+	if [[ "${IMG_WIDTH}" != +([+0-9]) ]]; then
+		ERROR_MSG="${ERROR_MSG}\n*** IMG_HEIGHT (${IMG_HEIGHT}) must be a number."
+	fi
+	if [ -n "${ERROR_MSG}" ]; then
+		echo -e "${RED}*** ${ME}: ERROR: Image resize number(s) invalid.${NC}"
+		echo -e "${RED}${ERROR_MSG}${NC}"
+		# Create a custom error message.
+		"${ALLSKY_SCRIPTS}/copy_notification_image.sh" --expires 15 "custom" \
+			"red" "" "85" "" "" "" "10" "red" "${EXTENSION}" "" \
+			"*** ERROR ***\nAllsky Stopped!\nInvalid IMG_RESIZE settings\nSee\n/var/log/allsky.log"
+
+		# Don't let the service restart us because we will get the same error again.
+		sudo systemctl stop allsky
+		exit ${EXIT_ERROR_STOP}
+	fi
+
 	[ "${ALLSKY_DEBUG_LEVEL}" -ge 4 ] && echo "${ME}: Resizing '${CURRENT_IMAGE}' to ${IMG_WIDTH}x${IMG_HEIGHT}"
 	convert "${CURRENT_IMAGE}" -resize "${IMG_WIDTH}x${IMG_HEIGHT}" "${CURRENT_IMAGE}"
 	if [ $? -ne 0 ] ; then
@@ -202,7 +223,7 @@ if [ "${CROP_IMAGE}" = "true" ] ; then
 			exit 4
 		fi
 	else
-		echo -e "${RED}*** ${ME}: ERROR: Crop failed.${NC}"
+		echo -e "${RED}*** ${ME}: ERROR: Crop number(s) invalid.${NC}"
 		echo -e "${RED}${ERROR_MSG}${NC}"
 		# Create a custom error message.
 		"${ALLSKY_SCRIPTS}/copy_notification_image.sh" --expires 15 "custom" \

--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -92,6 +92,21 @@ fi
 
 # If any of the "convert"s below fail, exit since we won't know if the file was corrupted.
 
+function display_error_and_exit()	# error message, notification string
+{
+	ERROR_MESSAGE="${1}"
+	NOTIFICATION_STRING="${2}"
+	echo -e "${RED}${ERROR_MESSAGE}${NC}"
+	# Create a custom error message.
+	"${ALLSKY_SCRIPTS}/copy_notification_image.sh" --expires 15 "custom" \
+		"red" "" "85" "" "" "" "10" "red" "${EXTENSION}" "" \
+		"*** ERROR ***\nAllsky Stopped!\nInvalid ${NOTIFICATION_STRING} settings\nSee\n/var/log/allsky.log"
+
+	# Don't let the service restart us because we will get the same error again.
+	sudo systemctl stop allsky
+	exit ${EXIT_ERROR_STOP}
+}
+
 # Resize the image if required
 if [ "${IMG_RESIZE}" = "true" ] ; then
 	# Make sure we were given numbers.
@@ -104,15 +119,7 @@ if [ "${IMG_RESIZE}" = "true" ] ; then
 	fi
 	if [ -n "${ERROR_MSG}" ]; then
 		echo -e "${RED}*** ${ME}: ERROR: Image resize number(s) invalid.${NC}"
-		echo -e "${RED}${ERROR_MSG}${NC}"
-		# Create a custom error message.
-		"${ALLSKY_SCRIPTS}/copy_notification_image.sh" --expires 15 "custom" \
-			"red" "" "85" "" "" "" "10" "red" "${EXTENSION}" "" \
-			"*** ERROR ***\nAllsky Stopped!\nInvalid IMG_RESIZE settings\nSee\n/var/log/allsky.log"
-
-		# Don't let the service restart us because we will get the same error again.
-		sudo systemctl stop allsky
-		exit ${EXIT_ERROR_STOP}
+		display_error_and_exit "${ERROR_MSG}" "IMG_RESIZE"
 	fi
 
 	[ "${ALLSKY_DEBUG_LEVEL}" -ge 4 ] && echo "${ME}: Resizing '${CURRENT_IMAGE}' to ${IMG_WIDTH}x${IMG_HEIGHT}"
@@ -224,15 +231,7 @@ if [ "${CROP_IMAGE}" = "true" ] ; then
 		fi
 	else
 		echo -e "${RED}*** ${ME}: ERROR: Crop number(s) invalid.${NC}"
-		echo -e "${RED}${ERROR_MSG}${NC}"
-		# Create a custom error message.
-		"${ALLSKY_SCRIPTS}/copy_notification_image.sh" --expires 15 "custom" \
-			"red" "" "85" "" "" "" "10" "red" "${EXTENSION}" "" \
-			"*** ERROR ***\nAllsky Stopped!\nInvalid CROP settings\nSee\n/var/log/allsky.log"
-
-		# Don't let the service restart us because we will get the same error again.
-		sudo systemctl stop allsky
-		exit ${EXIT_ERROR_STOP}
+		display_error_and_exit "${ERROR_MSG}" "CROP"
 	fi
 fi
 

--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -151,7 +151,7 @@ if [ "${CROP_IMAGE}" = "true" ] ; then
 		fi
 	else
 		if false; then		# for debugging - remove after we're 110% sure these crop checks work
-			echo "SENSOR_CENTER: X=$SENSOR_CENTER_X, Y=$SENSOR_CENTER_Y"
+			echo "IMAGE_CENTER: X=$IMAGE_CENTER_X, Y=$IMAGE_CENTER_Y"
 			echo "CROP_WIDTH=${CROP_WIDTH}, SENSOR WIDTH=${RESOLUTION_X}"
 			echo "CROP_HEIGHT=${CROP_HEIGHT}, SENSOR HEIGHT=${RESOLUTION_Y}"
 			if [ ! -z "${HALF_CROP_X}" ]; then
@@ -166,9 +166,9 @@ if [ "${CROP_IMAGE}" = "true" ] ; then
 		echo -e "${RED}*** ${ME}: ERROR: Crop failed.${NC}"
 		echo -e "${RED}${ERROR_MSG}${NC}"
 		# Create a custom error message.
-		"${ALLSKY_SCRIPTS}/generate_notification_images.sh" --directory "${ALLSKY_TMP}" "${FILENAME}" \
-			"red" "" "85" "" "" \
-			"" "10" "red" "${EXTENSION}" "" "CROP failed - bad size"
+		"${ALLSKY_SCRIPTS}/copy_notification_image.sh" --expires 15 "custom" \
+			"red" "" "85" "" "" "" "10" "red" "${EXTENSION}" "" \
+			"*** ERROR ***\nAllsky Stopped!\nInvalid CROP settings\nSee\n/var/log/allsky.log"
 
 		# Don't let the service restart us because we will get the same error again.
 		sudo systemctl stop allsky

--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -104,6 +104,12 @@ fi
 
 # Crop the image if required
 if [ "${CROP_IMAGE}" = "true" ] ; then
+	# If the image was just resized, the resolution changed, so reset the variables.
+	if [ "${IMG_RESIZE}" = "true" ] ; then
+		RESOLUTION_X=${IMG_WIDTH}
+		RESOLUTION_Y=${IMG_HEIGHT}
+	fi
+
 	# Do some sanity checks on the CROP_* variables.
 	# The crop rectangle needs to fit within the image, be an even number, and be greater than 0.
 	ERROR_MSG=""
@@ -140,7 +146,8 @@ if [ "${CROP_IMAGE}" = "true" ] ; then
 		typeset -i SENSOR_CENTER_X=$(( RESOLUTION_X / 2 ))
 		typeset -i SENSOR_CENTER_Y=$(( RESOLUTION_Y / 2 ))
 		typeset -i CROP_CENTER_ON_SENSOR_X=$(( SENSOR_CENTER_X + CROP_OFFSET_X ))
-		# There appears to be a bug in "convert" with "-gravity Center"; the Y offset is only applied half.
+		# There appears to be a bug in "convert" with "-gravity Center"; the Y offset is applied
+		# to the TOP of the image, not the CENTER.  The X offset is correctly applied to the image CENTER.
 		# Should the division round up or down or truncate (current method)?
 		typeset -i CROP_CENTER_ON_SENSOR_Y=$(( SENSOR_CENTER_Y + (CROP_OFFSET_Y / 2) ))
 		typeset -i HALF_CROP_WIDTH=$(( CROP_WIDTH / 2 ))


### PR DESCRIPTION
* Perform sanity checks on crop settings: the crop area must fit on the image, the crop width and height must be even numbers, and the offsets must be numbers.
* While I was at it, I also performed checks on IMG_WIDTH and IMG_HEIGHT.

* We should probably perform checks in ALL scripts that a variable is a number when it's expected to be one...