### PR TITLE
allsky.sh: check for missing RPiHQ software

### DIFF
--- a/allsky.sh
+++ b/allsky.sh
@@ -81,6 +81,12 @@ if [ "${CAMERA}" = "RPiHQ" ]; then
 	if [ ${RET} -eq 0 ]; then
 		RPiHQ_SOFTWARE_TO_USE="libcamera"
 	else
+		which raspistill > /dev/null
+		if [ $? -ne 0 ]; then
+			echo -e "${RED}*** FATAL ERROR: Can't determine what software to use forRPiHQ camera. Stopping.${NC}" >&2
+			doExit ${EXIT_ERROR_STOP} "Error" "${ERROR_MSG_PREFIX}\nRPiHQ software\nnot found!."
+		fi
+
 		RPiHQ_SOFTWARE_TO_USE="raspistill"
 		# Either libcamera isn't installed or it doesn't work, so try raspistill instead.
 


### PR DESCRIPTION
If a user's Pi doesn't have the `libcamera-still` command, allsky.sh currently assumes `raspistill `exists, and the capture_RPiHQ command will start, only to produce an error every time it tries to take a picture.
This PR checks the the existence of `raspistill` and produces a non-recoverable error if it doesn't exist (and `libcamera-still` doesn't either).