### PR TITLE
capture_RPiHQ.cpp: decrease manual exposure delay

### DIFF
--- a/src/capture_RPiHQ.cpp
+++ b/src/capture_RPiHQ.cpp
@@ -198,7 +198,7 @@ int RPiHQcapture(bool auto_exposure, int exposure_us, int bin, bool auto_gain, d
 		else
 		{
 			// Manual exposure shots don't need any time to home in since we're specifying the time.
-			ss << 10;
+			ss << 1;
 		}
 		command += " --timeout " + ss.str();
 		command += " --nopreview";


### PR DESCRIPTION
Manual exposures don't need a delay since the user specifies the exposure time, so the software doesn't have to do multiple captures to get the best exposure.