### PR TITLE
Support EXIT_NO_CAMERA

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ If you want your allsky camera added to the [Allsky map](http://www.thomasjacqui
 		* Latitude and longitude can now be specified as either a decimal number (e.g., 32.29) or with N, S, E, W (e.g., 32.29N).  The Allsky Website will always display with N, S, E, or W.
 		* Sanity checking is done on crop and image resize settings before performing those actions.  For example, sizes must be positive, even numbers, and the crop area must fit within the image.
 		* Sanity checking is done on Allsky Map data, for example, the URLs are reachable from the Internet.
+		* If the camera isn't found, a notification message stating that is displayed.
 		* Many minor enhancements were made.
 	* WebUI:
 		* The WebUI is now installed as part of the Allsky installation. The [allsky-portal](https://github.com/thomasjacquin/allsky-portal) repository will be removed.
@@ -512,6 +513,6 @@ If you want your allsky camera added to the [Allsky map](http://www.thomasjacqui
 
 <!------------------------------------------------------------------------------------------->
 ### Donation
-If you found this project useful, here's a link to send me a cup of coffee :)
+If you found this project useful, here's a link to send Thomas a cup of coffee :)
 
 [![](https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MEBU2KN75G2NG&source=url)

--- a/allsky.sh
+++ b/allsky.sh
@@ -19,7 +19,7 @@ function doExit()
 	TYPE=${2:-Error}
 	CUSTOM_MESSAGE="${3}"
 
-	if [ ${EXITCODE} -eq ${EXIT_ERROR_STOP} ]; then
+	if [ ${EXITCODE} -ge ${EXIT_ERROR_STOP} ]; then
 		# With fatal EXIT_ERROR_STOP errors, we can't continue so display a notification image
 		# even if the user has them turned off.
 		if [ -n "${CUSTOM_MESSAGE}" ]; then
@@ -61,7 +61,7 @@ USE_NOTIFICATION_IMAGES=$(jq -r '.notificationimages' "$CAMERA_SETTINGS")
 
 if [ -z "${CAMERA}" ]; then
 	echo -e "${RED}*** FATAL ERROR: CAMERA not set, can't continue!${NC}"
-	doExit ${EXIT_ERROR_STOP} "Error" "${ERROR_MSG_PREFIX}\nCAMERA type\nnot specified in\n$(basename ${ALLSKY_CONFIG})/config.sh."
+	doExit ${EXIT_NO_CAMERA} "Error" "${ERROR_MSG_PREFIX}\nCAMERA type\nnot specified in\n$(basename ${ALLSKY_CONFIG})/config.sh."
 fi
 
 # Make sure allsky.sh is not already running.
@@ -99,7 +99,7 @@ if [ "${CAMERA}" = "RPiHQ" ]; then
 	fi
 	if [ ${RET} -ne 0 ]; then
 		echo -e "${RED}*** FATAL ERROR: RPiHQ Camera not found.  Make sure it's enabled. Stopping.${NC}" >&2
-		doExit ${EXIT_ERROR_STOP} "Error" "${ERROR_MSG_PREFIX}\nRPiHQ Camera\nnot found!\nMake sure it's enabled."
+		doExit ${EXIT_NO_CAMERA} "Error" "${ERROR_MSG_PREFIX}\nRPiHQ Camera\nnot found!\nMake sure it's enabled."
 	fi
 
 elif [ "${CAMERA}" = "ZWO" ]; then
@@ -156,7 +156,7 @@ elif [ "${CAMERA}" = "ZWO" ]; then
 
 			echo "  If you have the 'uhubctl' command installed, add it to config.sh." >&2
 			echo "  In the meantime, try running it to reset the USB bus." >&2
-			doExit ${EXIT_ERROR_STOP} "Error" "${ERROR_MSG_PREFIX}\nNo ZWO camera\nfound!${USB_MSG}"
+			doExit ${EXIT_NO_CAMERA} "Error" "${ERROR_MSG_PREFIX}\nNo ZWO camera\nfound!${USB_MSG}"
 		fi
 	fi
 
@@ -164,7 +164,7 @@ elif [ "${CAMERA}" = "ZWO" ]; then
 
 else
 	echo -e "${RED}FATAL ERROR: Unknown CAMERA type: ${CAMERA}!  Stopping.${NC}" >&2
-	doExit ${EXIT_ERROR_STOP} "Error" "${ERROR_MSG_PREFIX}\nUnknown CAMERA\ntype: ${CAMERA}"
+	doExit ${EXIT_NO_CAMERA} "Error" "${ERROR_MSG_PREFIX}\nUnknown CAMERA\ntype: ${CAMERA}"
 fi
 
 echo "CAMERA: ${CAMERA}"

--- a/config_repo/allsky.service.repo
+++ b/config_repo/allsky.service.repo
@@ -8,8 +8,8 @@ ExecStart=/home/pi/allsky/allsky.sh
 SyslogFacility=local5
 Restart=on-success
 RestartSec=5
-; exit status 100 means fatal error the user needs to fix, so don't restart
-RestartPreventExitStatus=100
+; exit status 100 and higher mean a fatal error the user needs to fix, so don't restart
+RestartPreventExitStatus=100 101
 ; XXX RestartKillSignal is not recognized by the systemd that comes with Buster (not sure about Bullseye),
 ; so use ExecReload instead.
 ; RestartKillSignal=SIGUSR1

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1509,7 +1509,7 @@ i++;
 		printf("*** ERROR: No Connected Camera...\n");
 		// Don't wait here since it's possible the camera is physically connected
 		// but the software doesn't see it and the USB bus needs to be reset.
-		closeUp(EXIT_ERROR_STOP);		// If there are no cameras we can't do anything.
+		closeUp(EXIT_NO_CAMERA);		// If there are no cameras we can't do anything.
 	}
 
 	if (numDevices > 1)
@@ -1527,7 +1527,7 @@ i++;
 	if (asiRetCode != ASI_SUCCESS)
 	{
 		printf("*** ERROR opening camera, check that you have root permissions! (%s)\n", getRetCode(asiRetCode));
-		closeUp(EXIT_ERROR_STOP);				// Can't do anything so might as well exit.
+		closeUp(EXIT_NO_CAMERA);				// Can't do anything so might as well exit.
 	}
 
 	int iMaxWidth, iMaxHeight;

--- a/variables.sh
+++ b/variables.sh
@@ -66,8 +66,10 @@ if [ "${ALLSKY_VARIABLE_SET}" = "" ]; then
 	ALLSKY_WEBSITE=${ALLSKY_WEBSITE:-${ALLSKY_WEBUI}/allsky}
 
 	# These EXIT codes from the capture programs must match what's in src/include/allsky_common.h
+	# Anything at or above EXIT_ERROR_STOP is unrecoverable and the service must be stopped
 	EXIT_OK=0
 	EXIT_RESTARTING=98		# process is restarting, i.e., stop, then start
 	EXIT_RESET_USB=99		# need to reset USB bus; cannot continue
 	EXIT_ERROR_STOP=100		# unrecoverable error - need user action so stop service
+	EXIT_NO_CAMERA=101		# cannot find camera
 fi


### PR DESCRIPTION
This exit code is thrown when the camera can't be found.  A notification message is displayed and the service is stopped.