### PR TITLE
Add support for scp protocol in uploads

### DIFF
--- a/config_repo/ftp-settings.sh.repo
+++ b/config_repo/ftp-settings.sh.repo
@@ -12,7 +12,7 @@
 	#  "sftp"	(SSH file transfer) - uploads to an FTP server that supports secure transfer.
 	#		See the section for sftp PROTOCOL below.
 	#  "scp"	(secure copy) - copies to a remote server.
-	#		See the section for scp PROTOCOL below.   NOTE: "scp" PROTOCOL IS NOT IMPLEMENTED YET.
+	#		See the section for scp PROTOCOL below.
 	#  "S3"		uploads to an Amazon Web Services (AWS) server.
 	#		See the "S3 PROTOCOL only" section below.
 PROTOCOL=""
@@ -70,6 +70,7 @@ WEB_STARTRAILS_DIR=""
 	# Enter the name of the remote server.  If you don't know it, ask your service provider.
 REMOTE_HOST=""
 
+############### ftp, ftps, and sftp PROTOCOLS only:
 	# Enter the username of the login on the remote server.
 REMOTE_USER=""
 
@@ -83,6 +84,17 @@ REMOTE_PASSWORD=""
 	# This setting does not apply to the "scp" PROTOCOL.
 LFTP_COMMANDS=""
 
+############### scp PROTOCOL only:
+	# You will need to set up SSH key authentication on your server.
+	# First, generate a SSH key on your client:
+	#   ssh-keygen -t rsa
+	# When prompted, leave default filename, and use an empty passphrase.
+	# Then, copy the generated key to your server:
+	#   ssh-copy-id remote_username@server_ip_address
+	# The private SSH key will be stored in ~/.ssh (default filename is id_rsa)
+
+	# Enter the path to the SSH key
+SSH_KEY_FILE=""
 
 ############### S3 PROTOCOL only:
 	# You will need to install the AWS CLI:

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -121,6 +121,14 @@ elif [[ ${PROTOCOL} == "local" ]] ; then
 	cp "${FILE_TO_UPLOAD}" "${REMOTE_DIR}/${DESTINATION_FILE}"
 	RET=$?
 
+elif [[ "${PROTOCOL}" == "scp" ]] ; then
+	if [ "${SILENT}" = "false" -a "${ALLSKY_DEBUG_LEVEL}" -ge 3 ]; then
+		echo "${ME}: Copying ${FILE_TO_UPLOAD} to ${REMOTE_HOST}:${REMOTE_DIR}/${DESTINATION_FILE}"
+	fi
+
+	scp -i "${SSH_KEY_FILE}" "${FILE_TO_UPLOAD}" "${REMOTE_HOST}:${REMOTE_DIR}/${DESTINATION_FILE}"
+	RET=$?
+
 else # sftp/ftp/ftps
 	# People sometimes have problems with ftp not working,
 	# so save the commands we use so they can run lftp manually to debug.


### PR DESCRIPTION
Add support for using `scp` to upload images to a remote server. Requires use of SSH key authentication.

Support for username/password authentication in `scp` could be added in the future if needed.

# Test Plan

In `allsky` client (Raspberry Pi 4 host):
```
~/allsky/scripts $ ./upload.sh /tmp/test.txt allsky-website/images test.txt
upload.sh: Copying /tmp/test.txt to hectorramos.com:allsky-website/images/test.txt
test.txt                                      100%    0     0.0KB/s   00:00    
```

In remote server (allsky-website host):

```
~/allsky-website/images$ ls
image.jpg  test.txt
```

