### PR TITLE
ALLSKY_ABORTEDUPLOADS

### DIFF
--- a/allsky.sh
+++ b/allsky.sh
@@ -177,6 +177,7 @@ if [ -d "${ALLSKY_TMP}" ]; then
 	rm -f "${ALLSKY_TMP}/${FILENAME}"-202*.${EXTENSION}	# "202" for 2020 and later
 
 	# Clear out this file and allow the web server to write to it.
+	# shellcheck disable=SC2188
 	> "${ALLSKY_ABORTEDUPLOADS}"
 	sudo chgrp www-data "${ALLSKY_ABORTEDUPLOADS}"
 	sudo chmod 664 "${ALLSKY_ABORTEDUPLOADS}"

--- a/allsky.sh
+++ b/allsky.sh
@@ -175,6 +175,11 @@ fi
 if [ -d "${ALLSKY_TMP}" ]; then
 	# remove any lingering old image files.
 	rm -f "${ALLSKY_TMP}/${FILENAME}"-202*.${EXTENSION}	# "202" for 2020 and later
+
+	# Clear out this file and allow the web server to write to it.
+	> "${ALLSKY_ABORTEDUPLOADS}"
+	sudo chgrp www-data "${ALLSKY_ABORTEDUPLOADS}"
+	sudo chmod 664 "${ALLSKY_ABORTEDUPLOADS}"
 else
 	# Re-create in case it's on a memory filesystem that gets wiped out at reboot
 	mkdir -p "${ALLSKY_TMP}"
@@ -252,9 +257,12 @@ elif [[ $CAMERA == "RPiHQ" ]]; then
 	CAPTURE="capture_RPiHQ"
 fi
 rm -f "${ALLSKY_NOTIFICATION_LOG}"	# clear out any notificatons from prior runs.
-"${ALLSKY_HOME}/${CAPTURE}" "${ARGUMENTS[@]}"		# run the main program - this is the main attraction...
+# Run the main program - this is the main attraction...
+"${ALLSKY_HOME}/${CAPTURE}" "${ARGUMENTS[@]}"
 RETCODE=$?
 
+### TODO: can probably remove this code
+if false; then
 if [ ${RETCODE} -ne ${EXIT_OK} ]; then
 	# for testing
 	echo -e "${RED}'${CAPTURE}' exited with RETCODE=${RETCODE}${NC}"
@@ -263,6 +271,7 @@ if [ "${GOT_SIGTERM}" = "true" ] || [ "${GOT_SIGUSR1}" = "true" ] || [ "${GOT_SI
 	# for testing
 	echo "allsky.sh: GOT_SIGTERM=$GOT_SIGTERM, GOT_SIGUSR1=$GOT_SIGUSR1, GOT_SIGINT=$GOT_SIGINT"
 fi
+fi	# if false
 
 if [ "${RETCODE}" -eq ${EXIT_OK} ] ; then
 	doExit ${EXIT_OK} ""

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -90,6 +90,8 @@ if [ -f "${PID_FILE}" ]; then
 			echo -n " and delay settings."
 			ps -fp ${PID}
 			echo -e "${NC}"
+			# Keep track of aborts so user can be notified
+			echo -e "$(date)\t${FILE_TYPE}\t${FILE_TO_UPLOAD}" >> "${ALLSKY_ABORTEDUPLOADS}"
 			exit 99
 		fi
 fi

--- a/variables.sh
+++ b/variables.sh
@@ -59,6 +59,9 @@ if [ "${ALLSKY_VARIABLE_SET}" = "" ]; then
 	# Holds temporary messages to display in the WebUI.
 	ALLSKY_MESSAGES="${ALLSKY_TMP}/messages.txt"
 
+	# Holds temporary list of aborted uploads since another one was in progress
+	ALLSKY_ABORTEDUPLOADS="${ALLSKY_TMP}/aborted_uploads.txt"
+
 	# Holds all the dark frames.
 	ALLSKY_DARKS="${ALLSKY_DARKS:-${ALLSKY_HOME}/darks}"
 


### PR DESCRIPTION
Keep track of the number of aborted uploads due to another one in progress.  This can give the user an indication of whether or not they should decrease the frequency of uploading files, e.g., every other one.