### PR TITLE
endOfNight.sh: check for 'yesterday'

### DIFF
--- a/scripts/endOfNight.sh
+++ b/scripts/endOfNight.sh
@@ -22,7 +22,7 @@ if [ $# -eq 1 ] ; then
 		DATE="${1}"
 	fi
 else
-	DATE=$(date -d '12 hours ago' +'%Y%m%d')
+	DATE=$(date -d 'yesterday' +'%Y%m%d')
 fi
 
 DATE_DIR="${ALLSKY_IMAGES}/${DATE}"


### PR DESCRIPTION
* Determining what directory to look for images by using today's date - 12 hours only works if endOfNight.sh is called within 12 hours of the night-to-day transition, which it normally is.  However, if a user calls it manually they may call it late in the evening, for example, which might be 14 hours after the transition.  In this case, endOfNight.sh will use the current day's directory, which is still being written to.