### PR TITLE
Use CC_saveFile

### DIFF
--- a/src/ASI_functions.cpp
+++ b/src/ASI_functions.cpp
@@ -611,22 +611,19 @@ char *getCameraModel(ASI_CAMERA_INFO cameraInfo)
 }
 
 // Save information on the specified camera.
-void saveCameraInfo(ASI_CAMERA_INFO cameraInfo, char const *dir, int width, int height, double pixelSize, char const *bayer)
+void saveCameraInfo(ASI_CAMERA_INFO cameraInfo, char const *file, int width, int height, double pixelSize, char const *bayer)
 {
 	char *camModel = getCameraModel(cameraInfo);
 	char *sn = getSerialNumber(cameraInfo.CameraID);
 
-	char fileName[128];
-	snprintf(fileName, sizeof(fileName), "%s/%s_%s.json", dir, CAMERA_TYPE, camModel);
-	FILE *f = fopen(fileName, "w");
+	FILE *f = fopen(file, "w");
 	if (f == NULL)
 	{
-		Log(0, "ERROR: Unable to open '%s': %s\n", fileName, strerror(errno));
+		Log(0, "ERROR: Unable to open '%s': %s\n", file, strerror(errno));
 		closeUp(EXIT_ERROR_STOP);
 	}
-	Log(4, "saveCameraInfo(): saving to %s\n", fileName);
+	Log(4, "saveCameraInfo(): saving to %s\n", file);
 
-setlinebuf(f);
 	// output basic information on camera as well as all it's capabilities
 	fprintf(f, "{\n");
 	fprintf(f, "\t\"cameraType\" : \"%s\",\n", CAMERA_TYPE);

--- a/src/ASI_functions.cpp
+++ b/src/ASI_functions.cpp
@@ -215,8 +215,8 @@ char camerasInfoFile[128]	= { 0 };	// name of temporary file
 // TODO: use fork() and inter-process communication to get the info to avoid a temporary file.
 int ASIGetNumOfConnectedCameras()
 {
-	// CG.CC_saveDir should be specified, but in case it isn't...
-	const char *dir = CG.CC_saveDir;
+	// CG.saveDir should be specified, but in case it isn't...
+	const char *dir = CG.saveDir;
 	if (dir == NULL)
 		dir = CG.saveDir;
 	if (dir == NULL)
@@ -892,11 +892,8 @@ bool setDefaultsAndValidateSettings(config *cg, ASI_CAMERA_INFO ci)
 		snprintf(s, sizeof(s), "%s%s", cg->allskyHome, "tmp");
 		cg->saveDir = s;
 	}
-	if (cg->CC_saveDir == NULL)
-		cg->CC_saveDir = cg->saveDir;
 
 	cg->tty = isatty(fileno(stdout)) ? true : false;
-
 	cg->isColorCamera = ci.IsColorCam == ASI_TRUE ? true : false;
 	cg->isCooledCamera = ci.IsCoolerCam == ASI_TRUE ? true : false;
 

--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -1911,7 +1911,8 @@ bool getCommandLineArguments(config *cg, int argc, char *argv[])
 	}
 
 
-	if (cg->saveDir == NULL) {
+	// if cg_CC_saveFile is set, we'll output some info and exit, and won't take any images.
+	if (cg->saveDir == NULL && cg->CC_saveFile == NULL) {
 		cg->saveDir = cg->allskyHome;
 		Log(1, "*** WARNING: No directory to save Images was specified. Using: [%s]\n", cg->saveDir);
 	}

--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -1064,7 +1064,7 @@ void displayHelp(config cg)
 	printf("\nMisc. settings:\n");
 	printf(" -%-*s - Where to save 'filename' [%s].\n", n, "save_dir s", cg.saveDir);
 	printf(" -%-*s - 1 previews the captured images. Only works with a Desktop Environment [%s]\n", n, "preview", yesNo(cg.preview));
-	printf(" -%-*s - Outputs the camera's capabilities to the specified directory and exists.\n", n, "cc_save_dir s");
+	printf(" -%-*s - Outputs the camera's capabilities to the specified file and exists.\n", n, "cc_file s");
 	printf(" -%-*s - Set mean-value and activates exposure control [%.2f].\n", n, "mean-threshold n", cg.myModeMeanSetting.mean_threshold);
 	if (cg.ct == ctRPi) {
 		printf(" -%-*s - Command being used to take pictures (Buster: raspistill, Bullseye: libcamera-still\n", n, "cmd s");
@@ -1484,10 +1484,10 @@ bool getCommandLineArguments(config *cg, int argc, char *argv[])
 		{
 			cg->saveDir = argv[++i];
 		}
-		else if (strcmp(a, "cc_save_dir") == 0)
+		else if (strcmp(a, "cc_file") == 0)
 		{
-			cg->CC_saveDir = argv[++i];
-			// Since the user specified the CC_saveDir that means they want to save
+			cg->CC_saveFile = argv[++i];
+			// Since the user specified the CC_saveFile that means they want to save
 			// the camera capabilities and quit.
 			cg->saveCC = true;
 			cg->quietExit = true;	// we display info and quit
@@ -1911,13 +1911,10 @@ bool getCommandLineArguments(config *cg, int argc, char *argv[])
 	}
 
 
-	// if cg_CC_saveDir is set, we'll output some info and exit, and won't take any images.
-	if (cg->saveDir == NULL && cg->CC_saveDir == NULL) {
+	if (cg->saveDir == NULL) {
 		cg->saveDir = cg->allskyHome;
 		Log(1, "*** WARNING: No directory to save Images was specified. Using: [%s]\n", cg->saveDir);
 	}
-	if (cg->CC_saveDir == NULL)
-		cg->CC_saveDir = cg->saveDir;
 
 	return(true);
 }

--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -430,7 +430,7 @@ int main(int argc, char *argv[])
 
 	if (CG.saveCC)
 	{
-		saveCameraInfo(ASICameraInfo, CG.CC_saveDir, iMaxWidth, iMaxHeight, pixelSize, bayer[ASICameraInfo.BayerPattern]);
+		saveCameraInfo(ASICameraInfo, CG.CC_saveFile, iMaxWidth, iMaxHeight, pixelSize, bayer[ASICameraInfo.BayerPattern]);
 		closeUp(EXIT_OK);
 	}
 

--- a/src/capture_ZWO.cpp
+++ b/src/capture_ZWO.cpp
@@ -748,7 +748,7 @@ int main(int argc, char *argv[])
 
 	if (CG.saveCC)
 	{
-		saveCameraInfo(ASICameraInfo, CG.CC_saveDir, iMaxWidth, iMaxHeight, pixelSize, bayer[ASICameraInfo.BayerPattern]);
+		saveCameraInfo(ASICameraInfo, CG.CC_saveFile, iMaxWidth, iMaxHeight, pixelSize, bayer[ASICameraInfo.BayerPattern]);
 		closeUp(EXIT_OK);
 	}
 

--- a/src/include/allsky_common.h
+++ b/src/include/allsky_common.h
@@ -158,7 +158,7 @@ struct config {			// for configuration variables
 	bool isLibcamera					= true;			// RPi only
 	char const *cmdToUse				= NULL;			// RPi command to us to take images
 	char const *saveDir					= NULL;			// Directory to save images
-	char const *CC_saveDir				= NULL;			// Directory to save camera controls file
+	char const *CC_saveFile				= NULL;			// File to save camera controls to
 	bool saveCC							= false;		// Save camera controls file?
 	bool tty							= false;		// Running on a tty?
 	bool preview						= false;		// Display a preview windoe?


### PR DESCRIPTION
The invoker now specifies the FILE to save camera capabilities to, rather than the DIRECTORY.  This means a generic file name can be used so other scripts reading the file don't need to know the CAMERA_TYPE and CAMERA_MODEL, which are specified in the file, resulting in a catch-22.