### PR TITLE
configuration.json.repo: prepend "s_"

### DIFF
--- a/config_repo/configuration.json.repo
+++ b/config_repo/configuration.json.repo
@@ -85,8 +85,8 @@
 		"sidebarStyle": "",
 		"popoutIcons": [
 			{ "label": "Location",  "icon": "fa-map-marker-alt",  "variable": "location",  "value": "" },
-			{ "label": "Latitude",  "icon": "fa-map-marker",  "variable": "latitude",  "value": "" },
-			{ "label": "Longitude",  "icon": "fa-map-marker",  "variable": "longitude",  "value": "" },
+			{ "label": "Latitude",  "icon": "fa-map-marker",  "variable": "s_latitude",  "value": "" },
+			{ "label": "Longitude",  "icon": "fa-map-marker",  "variable": "s_longitude",  "value": "" },
 			{ "label": "Camera",  "icon": "fa-camera-retro",  "variable": "camera",  "value": "" },
 			{ "label": "Lens",  "icon": "fa-dot-circle",  "variable": "lens",  "value": "" },
 			{ "label": "Computer",  "icon": "fa-microchip",  "variable": "computer",  "value": "" },


### PR DESCRIPTION
For consistency, the website should display the latitude and longitude with N, S, E, and W, regardless of what's entered into the configuration file.  s_latitude and s_longitude display the "s"tring version of them, i.e., with N, S, E, W.