### PR TITLE
install.sh: use sudo chown

### DIFF
--- a/website/install.sh
+++ b/website/install.sh
@@ -379,7 +379,7 @@ mkdir -p startrails/thumbnails keograms/thumbnails videos/thumbnails
 
 echo -e "${GREEN}* Fixing ownership and permissions${NC}"
 U=$(id --name --user)		# User running this script
-chown -R "${U}:www-data" .
+sudo chown -R "${U}:www-data" .
 find ./ -type f -exec chmod 644 {} \;
 find ./ -type d -exec chmod 775 {} \;
 


### PR DESCRIPTION
In order for the login running website/install.sh to be able to chmod pi:www-data, it needs to either be in the "www-data" group, or run as sudo.  Apparently it's not in that group on some machines, so use "sudo".