### PR TITLE
index.php: Use different jquery

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -113,7 +113,7 @@ if ($useLogin) {
     <script src="dist/js/functions.js"></script>
 
     <!-- jQuery -->
-    <script src="/javascript/jquery/jquery.min.js"></script>
+    <script src="bower_components/jquery/dist/jquery.min.js"></script>
 
     <!-- Bootstrap Core JavaScript -->
     <script src="bower_components/bootstrap/dist/js/bootstrap.min.js"></script>


### PR DESCRIPTION
On Buster, "/javascript" was a lighttpd alias to /usr/share/javascript.  That doesn't exist on Bullseye (at least the light version), so use a different jQuery.