### PR TITLE
Simplify arguments to aegGetNextExposureSettings()

### DIFF
--- a/src/ASI_functions.cpp
+++ b/src/ASI_functions.cpp
@@ -180,7 +180,7 @@ ASI_CONTROL_CAPS ControlCapsArray[][MAX_NUM_CONTROL_CAPS] =
 		{ "Brightness", "Brightness", 1.0, -1.0, 0, NOT_SET, ASI_FALSE, ASI_TRUE, BRIGHTNESS },
 		{ "Saturation", "Saturation", 99.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SATURATION },
 		{ "Contrast", "Contrast", 99.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, CONTRAST },
-		{ "Sharpness", "Sharpness", 99.0, 0.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, SHARPNESS },
+		{ "Sharpness", "Sharpness", 99.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SHARPNESS },
 // TODO: what are these values?
 		{ "", "EV: Exposure compensation (not currently supported)", 99, 99, 0.0, NOT_SET, ASI_FALSE, ASI_FALSE, EV },
 

--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -738,7 +738,7 @@ int displayNotificationImage(char const *arguments)
 	char cmd[1024];
 
 	snprintf(cmd, sizeof(cmd)-1, "%sscripts/copy_notification_image.sh %s", CG.allskyHome, arguments);
-	Log(0, "Calling system(%s)\n", cmd);
+	Log(4, "Calling system(%s)\n", cmd);
 	return(system(cmd));
 }
 

--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -732,8 +732,6 @@ if (CG.lastExposure_us != myRaspistillSetting.shutter_us)
   Log(0, " xxxx lastExposure_us (%ld) != shutter_us (%ld)\n", CG.lastExposure_us, myRaspistillSetting.shutter_us);
 						aegGetNextExposureSettings(&CG, myRaspistillSetting, myModeMeanSetting);
 
-						Log(2, "  > Got exposure: %s, gain: %1.3f,", length_in_units(CG.lastExposure_us, false), CG.lastGain);
-						Log(2, " shutter: %s, quickstart: %d, mean=%1.3f\n", length_in_units(myRaspistillSetting.shutter_us, false), myModeMeanSetting.quickstart, CG.lastMean);
 						if (CG.lastMean == -1)
 						{
 							numErrors++;

--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -728,6 +728,7 @@ myModeMeanSetting.modeMean = CG.myModeMeanSetting.modeMean;
 					CG.lastMean = aegCalcMean(pRgb);
 					if (myModeMeanSetting.meanAuto != MEAN_AUTO_OFF)
 					{
+						// set myRaspistillSetting.shutter_us and myRaspistillSetting.analoggain
 						aegGetNextExposureSettings(&CG, myRaspistillSetting, myModeMeanSetting);
 
 						if (CG.lastMean == -1)

--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -730,7 +730,7 @@ myModeMeanSetting.modeMean = CG.myModeMeanSetting.modeMean;
 					{
 if (CG.lastExposure_us != myRaspistillSetting.shutter_us)
   Log(0, " xxxx lastExposure_us (%ld) != shutter_us (%ld)\n", CG.lastExposure_us, myRaspistillSetting.shutter_us);
-						aegGetNextExposureSettings(CG, myRaspistillSetting, myModeMeanSetting);
+						aegGetNextExposureSettings(&CG, myRaspistillSetting, myModeMeanSetting);
 
 						Log(2, "  > Got exposure: %s, gain: %1.3f,", length_in_units(CG.lastExposure_us, false), CG.lastGain);
 						Log(2, " shutter: %s, quickstart: %d, mean=%1.3f\n", length_in_units(myRaspistillSetting.shutter_us, false), myModeMeanSetting.quickstart, CG.lastMean);
@@ -757,6 +757,14 @@ if (CG.lastExposure_us != myRaspistillSetting.shutter_us)
 					}
 				}
 
+				// We skip the initial frames to give auto-exposure time to
+				// lock in on a good exposure.  If it does that quickly, stop skipping images.
+				if (CG.goodLastExposure && CG.currentSkipFrames > 0)
+				{
+					Log(2, "Turning off Skip Frames\n");
+					CG.currentSkipFrames = 0;
+				}
+
 				if (CG.currentSkipFrames > 0)
 				{
 					CG.currentSkipFrames--;
@@ -769,13 +777,6 @@ if (CG.lastExposure_us != myRaspistillSetting.shutter_us)
 				}
 				else
 				{
-					// We primarily skip the initial frames to give auto-exposure time to
-					// lock in on a good exposure.  If it does that quickly, stop skipping images.
-					if (CG.goodLastExposure)
-					{
-						CG.currentSkipFrames = 0;
-					}
-
 					char cmd[1100+sizeof(CG.allskyHome)];
 					Log(1, "  > Saving %s image '%s'\n", CG.takeDarkFrames ? "dark" : dayOrNight.c_str(), CG.finalFileName);
 					snprintf(cmd, sizeof(cmd), "%sscripts/saveImage.sh %s '%s'", CG.allskyHome, dayOrNight.c_str(), CG.fullFilename);

--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -728,8 +728,6 @@ myModeMeanSetting.modeMean = CG.myModeMeanSetting.modeMean;
 					CG.lastMean = aegCalcMean(pRgb);
 					if (myModeMeanSetting.meanAuto != MEAN_AUTO_OFF)
 					{
-if (CG.lastExposure_us != myRaspistillSetting.shutter_us)
-  Log(0, " xxxx lastExposure_us (%ld) != shutter_us (%ld)\n", CG.lastExposure_us, myRaspistillSetting.shutter_us);
 						aegGetNextExposureSettings(&CG, myRaspistillSetting, myModeMeanSetting);
 
 						if (CG.lastMean == -1)

--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -730,8 +730,7 @@ myModeMeanSetting.modeMean = CG.myModeMeanSetting.modeMean;
 					{
 if (CG.lastExposure_us != myRaspistillSetting.shutter_us)
   Log(0, " xxxx lastExposure_us (%ld) != shutter_us (%ld)\n", CG.lastExposure_us, myRaspistillSetting.shutter_us);
-						aegGetNextExposureSettings(CG.lastMean, CG.lastExposure_us, CG.lastGain,
-								myRaspistillSetting, myModeMeanSetting);
+						aegGetNextExposureSettings(CG, myRaspistillSetting, myModeMeanSetting);
 
 						Log(2, "  > Got exposure: %s, gain: %1.3f,", length_in_units(CG.lastExposure_us, false), CG.lastGain);
 						Log(2, " shutter: %s, quickstart: %d, mean=%1.3f\n", length_in_units(myRaspistillSetting.shutter_us, false), myModeMeanSetting.quickstart, CG.lastMean);

--- a/src/include/mode_mean.h
+++ b/src/include/mode_mean.h
@@ -46,4 +46,4 @@ struct modeMeanSetting {
 
 bool aegInit(config, int, double, raspistillSetting &, modeMeanSetting &);
 float aegCalcMean(cv::Mat);
-void aegGetNextExposureSettings(config, raspistillSetting &, modeMeanSetting &);
+void aegGetNextExposureSettings(config *, raspistillSetting &, modeMeanSetting &);

--- a/src/include/mode_mean.h
+++ b/src/include/mode_mean.h
@@ -22,23 +22,26 @@ typedef enum {
 struct modeMeanSetting {
 	bool modeMean = false;					// Activate mode mean.  User can change this.
 	MEAN_AUTO_MODE meanAuto = MEAN_AUTO_OFF; // Different modes are available - see MEAN_AUTO_MODE.
-	bool init = true;						// Set some settings before first calculation.
+	bool init				= true;			// Set some settings before first calculation.
 											// This is set to "false" after calculation.
-	double exposureLevelMin	= NOT_SET;		// Set during initialization.
-	double exposureLevelMax	= NOT_SET;		// Set during initialization.
-	double minGain = NOT_SET;				// Set during initialization.
-	double maxGain = NOT_SET;				// Set during initialization.
-	int maxExposure_us = NOT_SET;			// Set during initialization.
-	int minExposure_us = NOT_SET;			// Set during initialization.
-	double meanValue = NOT_SET;				// Default mean value for well exposed images.
-	double nightMean = DEFAULT_NIGHTMEAN;	// Default mean value for nighttime images.  User can change.
-	double dayMean = DEFAULT_DAYMEAN;		// Default mean value for daytime images.  User can change.
-	double mean_threshold = DEFAULT_MEAN_THRESHOLD;	// threshold value.
+	int exposureLevelMin	= NOT_SET;		// Set during initialization.
+	int exposureLevelMax	= NOT_SET;		// Set during initialization.
+	int exposureLevel		= NOT_SET;		// current ExposureLevel.
+	double minGain			= NOT_SET;		// Set during initialization.
+	double maxGain			= NOT_SET;		// Set during initialization.
+	long maxExposure_us		= NOT_SET;		// Set during initialization.
+	long minExposure_us		= NOT_SET;		// Set during initialization.
+	double meanValue		= NOT_SET;		// Default mean value for well exposed images.
+
+	// Default mean value for daytime and nighttime images.  User can change.
+	double dayMean			= DEFAULT_DAYMEAN;
+	double nightMean		= DEFAULT_NIGHTMEAN;
+	double mean_threshold	= DEFAULT_MEAN_THRESHOLD;	// threshold value.  User can change.
+
 	double const shuttersteps = 6.0;		// shuttersteps
-	int const historySize = 3;				// Number of last images for mean target calculation.
-	int quickstart = 10;					// Shorten delay between captures for this many images.
+	int const historySize	= 3;			// Number of last images for mean target calculation.
+	int quickstart			= 10;			// Shorten delay between captures for this many images.
 											// to help get us to a good exposure quicker.
-	int exposureLevel = NOT_SET;			// current ExposureLevel.
 	double mean_p0 = DEFAULT_MEAN_P0;		// ExposureChange (Steps) = p0 + p1 * diff + (p2*diff)^2
 	double mean_p1 = DEFAULT_MEAN_P1;
 	double mean_p2 = DEFAULT_MEAN_P2;

--- a/src/include/mode_mean.h
+++ b/src/include/mode_mean.h
@@ -46,4 +46,4 @@ struct modeMeanSetting {
 
 bool aegInit(config, int, double, raspistillSetting &, modeMeanSetting &);
 float aegCalcMean(cv::Mat);
-void aegGetNextExposureSettings(float, int, double, raspistillSetting &, modeMeanSetting &);
+void aegGetNextExposureSettings(config, raspistillSetting &, modeMeanSetting &);

--- a/src/mode_mean.cpp
+++ b/src/mode_mean.cpp
@@ -39,9 +39,9 @@ int calcExposureLevel(int exposure_us, double gain, modeMeanSetting &currentMode
 	return log(gain  * exposure_us/(double)US_IN_SEC) / log (2.0) * pow(currentModeMeanSetting.shuttersteps,2.0);
 }
 
-double calcExposureTimeEff (int exposureLevel, modeMeanSetting &currentModeMeanSetting)
+long calcExposureTimeEff_us(int exposureLevel, modeMeanSetting &currentModeMeanSetting)
 {
-	return pow(2.0, double(exposureLevel)/pow(currentModeMeanSetting.shuttersteps,2.0));
+	return (long)(pow(2.0, double(exposureLevel)/pow(currentModeMeanSetting.shuttersteps,2.0)) * US_IN_SEC);
 }
 
 // set limits.  aeg == Auto Exposure / Gain
@@ -105,8 +105,8 @@ bool aegInit(config cg, int minExposure_us, double minGain,
 	currentModeMeanSetting.minGain = minGain;
 	currentModeMeanSetting.maxGain = cg.currentMaxAutoGain;
 
-	Log(3, "  > Valid exposureLevels: %'1.3f to %'1.3f\n", currentModeMeanSetting.exposureLevelMin, currentModeMeanSetting.exposureLevelMax);
-	Log(3, "  > Starting:   exposure: %s, gain: %1.3f, exposure level: %d\n", length_in_units(cg.currentExposure_us, true), cg.currentGain, initialExposureLevel);
+	Log(4, "  > Valid exposureLevels: %'d to %'d starting at %d\n",
+		currentModeMeanSetting.exposureLevelMin, currentModeMeanSetting.exposureLevelMax, initialExposureLevel);
 
 	return true;
 }
@@ -175,14 +175,15 @@ float aegCalcMean(cv::Mat image)
 
 
 // Calculate the new exposure and gain values.
-void aegGetNextExposureSettings(float prevMean, int exposure_us, double gain,
+void aegGetNextExposureSettings(config * cg,
 		raspistillSetting & currentRaspistillSetting,
 		modeMeanSetting & currentModeMeanSetting)
 {
 	double mean_diff;
 	double max_;			// calculate std::max() by itself to make the code easier to read.
-	// get old exposureTime_s in seconds
-	double exposureTime_s = (double) currentRaspistillSetting.shutter_us/(double)US_IN_SEC;
+	// save prior exposure time.
+	long lastExposureTime_us = currentRaspistillSetting.shutter_us;
+	long newExposureTime_us = lastExposureTime_us;
 
 	static int values = 0;
 	// "values" will always be the same value for every image so only calculate once.
@@ -194,11 +195,11 @@ void aegGetNextExposureSettings(float prevMean, int exposure_us, double gain,
 		values += currentModeMeanSetting.historySize;
 	}
 
-	Log(3, "  > Just got:    shutter_us: %s, mean: %1.3f, target mean: %1.3f, diff (target - mean): %'1.3f, MeanCnt: %d, values: %d\n",
-		length_in_units(currentRaspistillSetting.shutter_us, true), prevMean,
-		currentModeMeanSetting.meanValue, (currentModeMeanSetting.meanValue - prevMean), MeanCnt, values);
+	Log(3, "  > Got:    shutter_us: %s, gain: %1.3f, mean: %1.3f, target mean: %1.3f, diff (target - mean): %'1.3f\n",
+		length_in_units(currentRaspistillSetting.shutter_us, true), cg->lastGain, cg->lastMean,
+		currentModeMeanSetting.meanValue, (currentModeMeanSetting.meanValue - cg->lastMean));
 
-	meanHistory[MeanCnt % currentModeMeanSetting.historySize] = prevMean;
+	meanHistory[MeanCnt % currentModeMeanSetting.historySize] = cg->lastMean;
 
 	int idx = (MeanCnt + currentModeMeanSetting.historySize) % currentModeMeanSetting.historySize;
 	int idxN1 = (MeanCnt + currentModeMeanSetting.historySize-1) % currentModeMeanSetting.historySize;
@@ -208,12 +209,12 @@ void aegGetNextExposureSettings(float prevMean, int exposure_us, double gain,
 
 	// mean_forcast = m_new + diff = m_new + (m_new - m_previous) = (2 * m_new) - m_previous
 	// If the previous mean was more than twice as large as the current one, mean_forecast will be negative.
-	double mean_forecast = (2.0 * meanHistory[idx]) - meanHistory[idxN1];	// "2.0 *" gives more weight to the current mean
-	max_ = std::max(mean_forecast, 0.0);
+	double mean_forecast = (2.0 * meanHistory[idx]) - meanHistory[idxN1];	// "2.0 *" gives more weight to the most recent mean
+	max_ = std::max(mean_forecast, 0.0);	// forces minimum of 0
 	mean_forecast = std::min(max_, currentModeMeanSetting.minGain);
 	// gleiche Wertigkeit wie aktueller Wert
 
-	// avg of mean history
+	// next mean is avg of mean history
 	double newMean = 0.0;
 	for (int i=1; i <= currentModeMeanSetting.historySize; i++) {
 		int ii =  (MeanCnt + i) % currentModeMeanSetting.historySize;
@@ -223,27 +224,29 @@ void aegGetNextExposureSettings(float prevMean, int exposure_us, double gain,
 	newMean += mean_forecast * currentModeMeanSetting.historySize;
 	newMean /= (double) values;
 	mean_diff = abs(newMean - currentModeMeanSetting.meanValue);
-	Log(3, "  > New mean: %1.3f, mean_forecast: %1.3f, mean_diff (newMean - target mean): %'1.3f, idx=%d, idxN1=%d\n", newMean, mean_forecast, mean_diff, idx, idxN1);
+	Log(3, "  > New mean target: %1.3f, mean_forecast: %1.3f, mean_diff (newMean - target mean): %'1.3f, idx=%d, idxN1=%d\n",
+		newMean, mean_forecast, mean_diff, idx, idxN1);
 
 	int ExposureChange;
 
 	// fast forward
 	if (fastforward || mean_diff > (currentModeMeanSetting.mean_threshold * 2.0)) {
-		// We are fairly far off from desired mean.
+		// We are fairly far off from desired mean so make a big change next time.
 		ExposureChange = std::max(1.0, currentModeMeanSetting.mean_p0 + (currentModeMeanSetting.mean_p1 * mean_diff) + pow(currentModeMeanSetting.mean_p2 * mean_diff, 2.0));
 		Log(3, "  > fast forward ExposureChange now %d (mean_diff=%1.3f > 2*threshold=%1.3f)\n", ExposureChange, mean_diff, currentModeMeanSetting.mean_threshold*2.0);
 	}
 	// slow forward
 	else if (mean_diff > currentModeMeanSetting.mean_threshold) {
-		// We are fairly close to desired mean.
+		// We are fairly close to desired mean so make a small change next time.
 		ExposureChange = std::max(1.0, currentModeMeanSetting.mean_p0 + currentModeMeanSetting.mean_p1 * mean_diff);
 		Log(3, "  > slow forward ExposureChange now %d (mean_diff=%1.3f, threshold=%1.3f)\n", ExposureChange, mean_diff, currentModeMeanSetting.mean_threshold);
 	}
 	else {
+		// We are within the threshold
 		ExposureChange = currentModeMeanSetting.shuttersteps / 2;
 	}
 
-	int const maxChange = 75;		// xxxxx for testing: s/50/75/
+	int const maxChange = 50;
 	ExposureChange = std::min(maxChange, ExposureChange);			// limit how big of a change we make each time
 	dExposureChange = ExposureChange - lastExposureChange;
 	lastExposureChange = ExposureChange;
@@ -251,34 +254,41 @@ void aegGetNextExposureSettings(float prevMean, int exposure_us, double gain,
 	Log(4, "  > ExposureChange clipped to %d (diff from last change: %d)\n", ExposureChange, dExposureChange);
 
 	// If the last image's mean was good, no changes are needed to the next one.
-	bool goodLastExposure = true;
 // TODO: make mean_threshold a percent instead of an actual value.  This will allow us to use 0 to 100 for what user enters as mean.
 
-	if (prevMean < (currentModeMeanSetting.meanValue - currentModeMeanSetting.mean_threshold)) {
+	if (cg->lastMean < (currentModeMeanSetting.meanValue - currentModeMeanSetting.mean_threshold)) {
 		// mean too low
-		if ((currentRaspistillSetting.analoggain < currentModeMeanSetting.maxGain) || (currentRaspistillSetting.shutter_us < currentModeMeanSetting.maxExposure_us)) {  // obere Grenze durch Gain und shutter
-			goodLastExposure = false;
+		if ((currentRaspistillSetting.analoggain < currentModeMeanSetting.maxGain)
+		 || (currentRaspistillSetting.shutter_us < currentModeMeanSetting.maxExposure_us)) {
+			// Under upper limit of gain and/or shutter time
+			cg->goodLastExposure = false;
 			currentModeMeanSetting.exposureLevel += ExposureChange;
 			Log(4, "  >> exposureLevel increased by %d to %d\n", ExposureChange, currentModeMeanSetting.exposureLevel);
 		}
 		else {
-			Log(3, "  >> Already at max gain (%1.3f) and/or max exposure (%s) - can't go any higher!\n", currentModeMeanSetting.maxGain, length_in_units(currentModeMeanSetting.maxExposure_us, true));
+			Log(3, "  >> Already at max gain (%1.3f) and max exposure (%s) - can't go any higher!\n",
+				currentModeMeanSetting.maxGain, length_in_units(currentModeMeanSetting.maxExposure_us, true));
 		}
 	}
-	else if (prevMean > (currentModeMeanSetting.meanValue + currentModeMeanSetting.mean_threshold))  {
+	else if (cg->lastMean > (currentModeMeanSetting.meanValue + currentModeMeanSetting.mean_threshold))  {
 		// mean too high
-/// xxxxxxx how about minGain?
-		if (exposureTime_s > currentModeMeanSetting.minExposure_us / (double)US_IN_SEC) { // untere Grenze durch shuttertime
-			goodLastExposure = false;
+/// Eric added minGain
+		if ((currentRaspistillSetting.analoggain > currentModeMeanSetting.minGain)
+		 || (lastExposureTime_us > currentModeMeanSetting.minExposure_us)) {
+			// Above lower limit of gain and/or shutter time
+			cg->goodLastExposure = false;
 			currentModeMeanSetting.exposureLevel -= ExposureChange;
 			Log(4, "  > exposureLevel decreased by %d to %d\n", ExposureChange, currentModeMeanSetting.exposureLevel);
 		}
 		else {
-			Log(3, "  >> Already at min exposure (%'d us) - can't go any lower!\n", currentModeMeanSetting.minExposure_us);
+			Log(3, "  >> Already at min gain (%1.3f) and min exposure (%'d us) - can't go any lower!\n",
+				currentModeMeanSetting.minGain, length_in_units(currentModeMeanSetting.minExposure_us, true));
 		}
 	}
 	else {
-		Log(3, "  >> Prior image mean good - no changes needed, mean=%1.3f, target mean=%1.3f threshold=%1.3f +++++++++\n", prevMean, currentModeMeanSetting.meanValue, currentModeMeanSetting.mean_threshold);
+		Log(3, "  > ++++++++++ Prior image mean good - no changes needed, mean=%1.3f, target mean=%1.3f threshold=%1.3f\n",
+			cg->lastMean, currentModeMeanSetting.meanValue, currentModeMeanSetting.mean_threshold);
+		cg->goodLastExposure = true;
 		if (currentModeMeanSetting.quickstart > 0)
 		{
 			currentModeMeanSetting.quickstart = 0;		// Got a good exposure - turn quickstart off if on
@@ -287,35 +297,35 @@ void aegGetNextExposureSettings(float prevMean, int exposure_us, double gain,
 	}
 
 	// Make sure exposureLevel is within min - max range.
-	max_ = std::max(currentModeMeanSetting.exposureLevel, (int)currentModeMeanSetting.exposureLevelMin);
-	currentModeMeanSetting.exposureLevel = std::min((int)max_, (int)currentModeMeanSetting.exposureLevelMax);
-	double exposureTimeEff_s = calcExposureTimeEff(currentModeMeanSetting.exposureLevel, currentModeMeanSetting);
+	max_ = std::max(currentModeMeanSetting.exposureLevel, currentModeMeanSetting.exposureLevelMin);
+	currentModeMeanSetting.exposureLevel = std::min((int)max_, currentModeMeanSetting.exposureLevelMax);
+	long exposureTimeEff_us = calcExposureTimeEff_us(currentModeMeanSetting.exposureLevel, currentModeMeanSetting);
 
 	// fastforward ?
-	if ((currentModeMeanSetting.exposureLevel == (int)currentModeMeanSetting.exposureLevelMax) || (currentModeMeanSetting.exposureLevel == (int)currentModeMeanSetting.exposureLevelMin)) {
+	if ((currentModeMeanSetting.exposureLevel == currentModeMeanSetting.exposureLevelMax) || (currentModeMeanSetting.exposureLevel == currentModeMeanSetting.exposureLevelMin)) {
 		fastforward = true;
 		Log(4, "  > FF activated\n");
 	}
 	if (fastforward &&
 		(abs(meanHistory[idx] - currentModeMeanSetting.meanValue) < currentModeMeanSetting.mean_threshold) &&
 		(abs(meanHistory[idxN1] - currentModeMeanSetting.meanValue) < currentModeMeanSetting.mean_threshold)) {
-printf(">>>>>>>>> fastforward=%s\n", fastforward ? "true" : "false");
 		fastforward = false;
 		Log(4, "  > FF deactivated\n");
 	}
 
 	//########################################################################
 	// calculate new gain
-	if (! goodLastExposure)
+	if (! cg->goodLastExposure)
 	{
-
-// xxxx TODO:  when INCREASING the mean, the gain goes to the max before the exposure increases.
-// It should increase exposure, then gain, then exposure, ...
-
 		if (currentModeMeanSetting.meanAuto == MEAN_AUTO || currentModeMeanSetting.meanAuto == MEAN_AUTO_GAIN_ONLY) {
-// xxxxxxx ??? "exposure_us" or maxExposure_us or exposureTime_s ?
-			max_ = std::max(currentModeMeanSetting.minGain, exposureTimeEff_s / (exposure_us/(double)US_IN_SEC));
-			// xxxx  double newGain = std::min(gain, max_);
+
+// xxxxxxx ??? "cg->lastExposure_us" or cg->maxExposure_us or lastExposureTime_us ?
+// Eric had cg->lastExposure_us and cg->lastGain; Andreas suggested trying cg->currentExposure_us and cg->currentGain.
+// It didn't make any difference - gain still increased to max before exposure increased.
+// Last and current exposure and gain are the same when we enter this function.
+
+			max_ = std::max(currentModeMeanSetting.minGain, (double)exposureTimeEff_us  / (double)cg->currentExposure_us);
+// xxxx  was: double newGain = std::min(cg->currentGain, max_);
 			double newGain = std::min(currentModeMeanSetting.maxGain, max_);
 			if (newGain > currentModeMeanSetting.maxGain) {
 				currentRaspistillSetting.analoggain = currentModeMeanSetting.maxGain;
@@ -327,40 +337,39 @@ printf(">>>>>>>>> fastforward=%s\n", fastforward ? "true" : "false");
 			}
 			else if (currentRaspistillSetting.analoggain != newGain) {
 				currentRaspistillSetting.analoggain = newGain;
-				Log(3, "  >> Setting new analoggain to %1.3f\n", newGain);
+				// Will be logged at end
 			}
 			else {
 				char const *isWhat = ((newGain == currentModeMeanSetting.minGain) || (newGain == currentModeMeanSetting.maxGain)) ? "possible" : "needed";
 				Log(3, "  >> No change to analoggain is %s (is %1.3f) +++\n", isWhat, newGain);
 			}
 		}
-		else if (currentRaspistillSetting.analoggain != gain) {
-			// it should already be at "gain", but just in case, set it anyhow
-			currentRaspistillSetting.analoggain = gain;
-			Log(3, "  >> setting new gain to %1.3f\n", gain);
+		else if (currentRaspistillSetting.analoggain != cg->currentGain) {
+			// it should already be at "cg->currentGain", but just in case, set it anyhow
+			currentRaspistillSetting.analoggain = cg->currentGain;
+			Log(3, "  >> setting new gain to currentGain: %1.3f\n", cg->currentGain);
 		}
  
 		// calculate new exposure time based on the (possibly) new gain
 		if (currentModeMeanSetting.meanAuto == MEAN_AUTO || currentModeMeanSetting.meanAuto == MEAN_AUTO_EXPOSURE_ONLY) {
-			max_ = std::max((double)currentModeMeanSetting.minExposure_us / (double)US_IN_SEC, exposureTimeEff_s / currentRaspistillSetting.analoggain);
-			double eOLD_s = exposureTime_s * US_IN_SEC;
-			double eNEW_s = std::min((double)currentModeMeanSetting.maxExposure_us / (double)US_IN_SEC, max_);
-			if (exposureTime_s == eNEW_s) {
+			max_ = std::max(currentModeMeanSetting.minExposure_us, (long)((double)exposureTimeEff_us / currentRaspistillSetting.analoggain));
+Log(3, "  > XXXX 1 max_ = %s us,", length_in_units(max_, true));
+Log(3, " exposureTimeEff_s=%s\n", length_in_units(exposureTimeEff_us, true));
+			long eNEW_us = std::min(currentModeMeanSetting.maxExposure_us, (long)max_);
+			long diff_us = abs(lastExposureTime_us - eNEW_us);
+			if (diff_us == 0) {
 				Log(3, "  >> No change to exposure time needed +++\n");
 			}
 			else {
-				Log(3, "  >> Setting new exposureTime_s to %s ", length_in_units((long)(eNEW_s * US_IN_SEC), true));
-				Log(3, "(was %s: ", length_in_units(eOLD_s, true));
-				Log(3, "diff %s)\n", length_in_units((eNEW_s-exposureTime_s) * US_IN_SEC, true));
-				exposureTime_s = eNEW_s;
+				Log(3, "  >> Setting new newExposureTime_us to %s ", length_in_units(eNEW_us, true));
+				Log(3, "(was %s: ", length_in_units(lastExposureTime_us, true));
+				Log(3, "diff %s)\n", length_in_units(eNEW_us - lastExposureTime_us, true));
+				newExposureTime_us = eNEW_us;
 			}
 		}
-		else if (0 && currentModeMeanSetting.meanAuto == MEAN_AUTO_EXPOSURE_ONLY) {		// xxxxx don't use
-			max_ = std::max((double)currentModeMeanSetting.minExposure_us / (double)US_IN_SEC, exposureTimeEff_s / currentRaspistillSetting.analoggain);
-			exposureTime_s = std::min((double)currentModeMeanSetting.maxExposure_us / (double)US_IN_SEC, max_);
-		}
 		else { // MEAN_AUTO_GAIN_ONLY || MEAN_AUTO_OFF
-			// exposureTime_s = (double)exposure_us/(double)US_IN_SEC;		// leave exposure alone
+			newExposureTime_us = cg->currentExposure_us;		// leave exposure alone
+			Log(3, "setting newExposureTime_us to cg->currentExposure_us = %s\n", length_in_units(newExposureTime_us, true));
 		}
 	}
 
@@ -373,10 +382,15 @@ printf(">>>>>>>>> fastforward=%s\n", fastforward ? "true" : "false");
 	MeanCnt++;
 	exposureLevelHistory[MeanCnt % currentModeMeanSetting.historySize] = currentModeMeanSetting.exposureLevel;
 
-	currentRaspistillSetting.shutter_us = exposureTime_s * (double)US_IN_SEC;
-	Log(3, "  > Next image:  mean: %'1.3f (diff from target: %'1.3f), Exposure level: %'d (minus %d: %d), Exposure time: %s, gain: %1.2f\n",
-		newMean, mean_diff,
-		currentModeMeanSetting.exposureLevel,
-		exposureLevelHistory[idx], currentModeMeanSetting.exposureLevel - exposureLevelHistory[idx],
-		length_in_units(currentRaspistillSetting.shutter_us, true), currentRaspistillSetting.analoggain);
+	currentRaspistillSetting.shutter_us = newExposureTime_us;
+
+	if (! cg->goodLastExposure) {
+		// If the last exposure was good, we're not changing anything so don't log anything.
+		Log(3, "  > Next image:  exposure time: %s, gain: %1.3f\n",
+			length_in_units(currentRaspistillSetting.shutter_us, true), currentRaspistillSetting.analoggain);
+		Log(3, "                 mean: %'1.3f (diff from target: %'1.3f), Exposure level: %'d (minus %d: %d)\n",
+			newMean, mean_diff,
+			currentModeMeanSetting.exposureLevel,
+			exposureLevelHistory[idx], currentModeMeanSetting.exposureLevel - exposureLevelHistory[idx]);
+	}
 }


### PR DESCRIPTION
* Changed exposure-related variables to _us longs rather than some double, some _s, and some _us.  It was too confusing.
* Also added/changed comments and Log() messages.

**TODO: fix algorithm where the gain goes to max value before exposure changes.**