### PR TITLE
Web UI use 'allskyDefines.inc'

### DIFF
--- a/config_repo/allskyDefines.inc.repo
+++ b/config_repo/allskyDefines.inc.repo
@@ -1,0 +1,30 @@
+<?php
+
+// These values are updated during installation.
+define('ALLSKY_HOME',    'XX_ALLSKY_HOME_XX');
+define('ALLSKY_SCRIPTS', 'XX_ALLSKY_SCRIPTS_XX');
+define('ALLSKY_IMAGES',  'XX_ALLSKY_IMAGES_XX');
+define('ALLSKY_CONFIG',  'XX_ALLSKY_CONFIG_XX');
+define('ALLSKY_WEBUI',  'XX_ALLSKY_WEBUI_XX');
+define('ALLSKY_WEBSITE',  'XX_ALLSKY_WEBSITE_XX');
+define('ALLSKY_OWNER', 'XX_ALLSKY_OWNER_XX');
+define('ALLSKY_GROUP', 'XX_ALLSKY_GROUP_XX');
+define('ALLSKY_MESSAGES',  'XX_ALLSKY_MESSAGES_XX');
+define('ALLSKY_REPO',  'XX_ALLSKY_REPO_XX');
+define('RASPI_CONFIG',   'XX_RASPI_CONFIG_XX');
+
+// Split the placeholder so it doesn't get replaced.
+if (ALLSKY_HOME == "XX_ALLSKY_HOME" . "_XX") {
+	// This file hasn't been updated yet after installation.
+	// This would only happen if they updated this file and not the whole Allsky release,
+	// which is hard since we only come out with releases.
+	echo "<div style='font-size: 200%;'>";
+	echo "<span style='color: red'>";
+	echo "Please run the following from the 'allsky' directory before using the WebUI:";
+	echo "</span>";
+	echo "<code>   ./install.sh --update</code>";
+	echo "</div>";
+	exit;
+}
+
+?>

--- a/config_repo/allskyDefines.inc.repo
+++ b/config_repo/allskyDefines.inc.repo
@@ -2,15 +2,16 @@
 
 // These values are updated during installation.
 define('ALLSKY_HOME',    'XX_ALLSKY_HOME_XX');
+define('ALLSKY_CONFIG',  'XX_ALLSKY_CONFIG_XX');
 define('ALLSKY_SCRIPTS', 'XX_ALLSKY_SCRIPTS_XX');
 define('ALLSKY_IMAGES',  'XX_ALLSKY_IMAGES_XX');
-define('ALLSKY_CONFIG',  'XX_ALLSKY_CONFIG_XX');
+define('ALLSKY_MESSAGES',  'XX_ALLSKY_MESSAGES_XX');
 define('ALLSKY_WEBUI',  'XX_ALLSKY_WEBUI_XX');
 define('ALLSKY_WEBSITE',  'XX_ALLSKY_WEBSITE_XX');
 define('ALLSKY_OWNER', 'XX_ALLSKY_OWNER_XX');
 define('ALLSKY_GROUP', 'XX_ALLSKY_GROUP_XX');
-define('ALLSKY_MESSAGES',  'XX_ALLSKY_MESSAGES_XX');
 define('ALLSKY_REPO',  'XX_ALLSKY_REPO_XX');
+define('ALLSKY_VERSION',  'XX_ALLSKY_VERSION_XX');
 define('RASPI_CONFIG',   'XX_RASPI_CONFIG_XX');
 
 // Split the placeholder so it doesn't get replaced.

--- a/html/includes/functions.php
+++ b/html/includes/functions.php
@@ -10,20 +10,6 @@
 // Sets all the define() variables.
 require 'allskyDefines.inc';
 
-// Split the placeholder so it doesn't get replaced.
-if (ALLSKY_HOME == "XX_ALLSKY_HOME" . "_XX") {
-	// This file hasn't been updated yet after installation.
-	// This would only happen if they updated this file and not the whole Allsky release,
-	// which is hard since we only come out with releases.
-	echo "<div style='font-size: 200%;'>";
-	echo "<span style='color: red'>";
-	echo "Please run the following from the 'allsky' directory before using the WebUI:";
-	echo "</span>";
-	echo "<code>   ./install.sh --update</code>";
-	echo "</div>";
-	exit;
-}
-
 $status = null;		// Global pointer to status messages
 $image_name=null; $delay=null; $daydelay=null; $nightdelay=null; $darkframe=null; $useLogin=null;
 

--- a/html/includes/functions.php
+++ b/html/includes/functions.php
@@ -7,18 +7,8 @@
  *
 */
 
-// These values are updated during installation.
-define('ALLSKY_HOME',    'XX_ALLSKY_HOME_XX');
-define('ALLSKY_SCRIPTS', 'XX_ALLSKY_SCRIPTS_XX');
-define('ALLSKY_IMAGES',  'XX_ALLSKY_IMAGES_XX');
-define('ALLSKY_CONFIG',  'XX_ALLSKY_CONFIG_XX');
-define('ALLSKY_WEBUI',  'XX_ALLSKY_WEBUI_XX');
-define('ALLSKY_WEBSITE',  'XX_ALLSKY_WEBSITE_XX');
-define('ALLSKY_OWNER', 'XX_ALLSKY_OWNER_XX');
-define('ALLSKY_GROUP', 'XX_ALLSKY_GROUP_XX');
-define('ALLSKY_MESSAGES',  'XX_ALLSKY_MESSAGES_XX');
-define('ALLSKY_REPO',  'XX_ALLSKY_REPO_XX');
-define('RASPI_CONFIG',   'XX_RASPI_CONFIG_XX');
+// Sets all the define() variables.
+require 'allskyDefines.inc';
 
 // Split the placeholder so it doesn't get replaced.
 if (ALLSKY_HOME == "XX_ALLSKY_HOME" . "_XX") {

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,7 @@ ALLSKY_OWNER=$(id --group --name)
 ALLSKY_GROUP=${ALLSKY_OWNER}
 ALLSKY_VERSION="$( < "${ALLSKY_HOME}/version" )"
 REPO_SUDOERS_FILE="${ALLSKY_REPO}/sudoers.repo"
+REPO_WEBUI_DEFINES_FILE="${ALLSKY_REPO}/allskyDefines.inc.repo"
 FINAL_SUDOERS_FILE="/etc/sudoers.d/allsky"
 
 
@@ -153,12 +154,13 @@ save_camera_capabilities() {
 }
 
 
-# Some files have placeholders for certain locations.  Modify them.
+# Modify placeholders for various directories.
 modify_locations()
 {
-	display_msg progress "Modifying locations in web files."
+	display_msg progress "Modifying locations for WebUI."
+	FILE="${ALLSKY_WEBUI}/includes/allskyDefines.inc"
 
-	sed -i  -e "s;XX_ALLSKY_HOME_XX;${ALLSKY_HOME};" \
+	sed		-e "s;XX_ALLSKY_HOME_XX;${ALLSKY_HOME};" \
 			-e "s;XX_ALLSKY_CONFIG_XX;${ALLSKY_CONFIG};" \
 			-e "s;XX_ALLSKY_SCRIPTS_XX;${ALLSKY_SCRIPTS};" \
 			-e "s;XX_ALLSKY_IMAGES_XX;${ALLSKY_IMAGES};" \
@@ -170,7 +172,8 @@ modify_locations()
 			-e "s;XX_ALLSKY_REPO_XX;${ALLSKY_REPO};" \
 			-e "s;XX_ALLSKY_VERSION_XX;${ALLSKY_VERSION};" \
 			-e "s;XX_RASPI_CONFIG_XX;${ALLSKY_CONFIG};" \
-		"${ALLSKY_WEBUI}/includes/functions.php"
+		"${REPO_WEBUI_DEFINES_FILE}"  >  "${FILE}"
+		chmod 644 "{FILE}"
 }
 
 do_sudoers()


### PR DESCRIPTION
Move the  define() statements out of includes/functions.php into a new "allskyDefines.inc" file that is created during installation based on the .repo version.  This makes maintenance a little easier.