### PR TITLE
Exposure bug fix

### DIFF
--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -164,11 +164,6 @@ int RPicapture(config cg, cv::Mat *image)
 
 	if (myModeMeanSetting.meanAuto != MEAN_AUTO_OFF)
 	{
-if (0 && cg.currentExposure_us != myRaspistillSetting.shutter_us)
-{
-printf("xxxxxxxxxxx cg.currentExposure_us = %s != ", length_in_units(cg.currentExposure_us, true));
-printf(" myRaspistillSetting.shutter_us= %s\n", length_in_units(myRaspistillSetting.shutter_us, true));
-}
 		cg.currentExposure_us = myRaspistillSetting.shutter_us;
 	}
 
@@ -624,7 +619,7 @@ int main(int argc, char *argv[])
 		{
 			CG.myModeMeanSetting.modeMean = true;
 			myModeMeanSetting.meanValue = CG.myModeMeanSetting.currentMean;
-			if (! aegInit(CG, CG.cameraMinExposure_us, CG.cameraMinGain, myRaspistillSetting, myModeMeanSetting))
+			if (! aegInit(CG, myRaspistillSetting, myModeMeanSetting))
 			{
 				closeUp(EXIT_ERROR_STOP);
 			}

--- a/src/include/mode_mean.h
+++ b/src/include/mode_mean.h
@@ -47,6 +47,6 @@ struct modeMeanSetting {
 	double mean_p2 = DEFAULT_MEAN_P2;
 };
 
-bool aegInit(config, int, double, raspistillSetting &, modeMeanSetting &);
+bool aegInit(config, raspistillSetting &, modeMeanSetting &);
 float aegCalcMean(cv::Mat);
 void aegGetNextExposureSettings(config *, raspistillSetting &, modeMeanSetting &);

--- a/src/mode_mean.cpp
+++ b/src/mode_mean.cpp
@@ -45,7 +45,7 @@ long calcExposureTimeEff_us(int exposureLevel, modeMeanSetting &currentModeMeanS
 }
 
 // set limits.  aeg == Auto Exposure / Gain
-bool aegInit(config cg, int exposure_us, double gain,
+bool aegInit(config cg,
 		raspistillSetting &currentRaspistillSetting, modeMeanSetting &currentModeMeanSetting)
 {
 	// Init some values first

--- a/src/mode_mean.cpp
+++ b/src/mode_mean.cpp
@@ -102,7 +102,7 @@ bool aegInit(config cg, int exposure_us, double gain,
 	}
 	currentModeMeanSetting.minExposure_us = cg.cameraMinExposure_us;
 	currentModeMeanSetting.maxExposure_us = cg.currentMaxAutoExposure_us;
-	currentModeMeanSetting.minGain = cg.cameraMinGain.
+	currentModeMeanSetting.minGain = cg.cameraMinGain;
 	currentModeMeanSetting.maxGain = cg.currentMaxAutoGain;
 
 	Log(4, "  > Valid exposureLevels: %'d to %'d starting at %d\n",
@@ -339,7 +339,7 @@ void aegGetNextExposureSettings(config * cg,
 			double newGain = std::min(cg->currentGain, max_);
 
 			max_ = std::max((double)cg->cameraMinExposure_us, (double)exposureTimeEff_us / newGain);
-			newExposureTime_us = std::min((double)cg->currentExposure_us, max_)
+			newExposureTime_us = std::min((double)cg->currentExposure_us, max_);
 
 printf("=== newGain=%f, cg->currentExposure_us=%s, max=%f\n", newGain, length_in_units(cg->currentExposure_us, true), max_);
 printf("===== exposureTimeEff_us=%s\n", length_in_units(exposureTimeEff_us, true));
@@ -367,15 +367,15 @@ printf("===== exposureTimeEff_us=%s\n", length_in_units(exposureTimeEff_us, true
 			}
 		}
 
-		else if (currentModeMeanSetting.mean_auto == MEAN_AUTO_GAIN_ONLY) {
+		else if (currentModeMeanSetting.meanAuto == MEAN_AUTO_GAIN_ONLY) {
 			newExposureTime_us = cg->currentExposure_us;
-			max_ = std::max((double)cg->minCameraGain, (double)ExposureTimeEff_us / (double)cg->currentExposure_us);
-			currentRaspistillSetting.analoggain = std::min(cg->currentGain, max);
+			max_ = std::max((double)cg->cameraMinGain, (double)exposureTimeEff_us / (double)cg->currentExposure_us);
+			currentRaspistillSetting.analoggain = std::min(cg->currentGain, max_);
 		}
 
-		else if (currentModeMeanSetting.mean_auto == MEAN_AUTO_EXPOSURE_ONLY) {
+		else if (currentModeMeanSetting.meanAuto == MEAN_AUTO_EXPOSURE_ONLY) {
 			currentRaspistillSetting.analoggain = cg->currentGain;
-			max_ = std::max((double)cg->cameraMinExposure, (double)ExposureTimeEff_us / cg->currentGain);
+			max_ = std::max((double)cg->cameraMinExposure_us, (double)exposureTimeEff_us / cg->currentGain);
 			newExposureTime_us = std::min((double)cg->currentExposure_us, max_);
 		}
 


### PR DESCRIPTION
Fix the bug where exposure increases to its max, but gain never changes.
This was because incorrect arguments were passed to the aegInit() and aegGetNextExposureSettings() due to my incomplete understanding of the algorithm.