### PR TITLE
Remove quickstart, use skip frames instead

### DIFF
--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -779,21 +779,12 @@ myModeMeanSetting.modeMean = CG.myModeMeanSetting.modeMean;
 					system(cmd);
 				}
 
-				if (myModeMeanSetting.quickstart && myModeMeanSetting.meanAuto != MEAN_AUTO_OFF)
-				{
-					long x = 1 * US_IN_SEC;
-					Log(2, "Sleeping 1 second (quickstart on, %d left)...\n", myModeMeanSetting.quickstart);
-					usleep(x);
-				}
+				std::string s;
+				if (CG.currentAutoExposure)
+					s = "auto";
 				else
-				{
-					std::string s;
-					if (CG.currentAutoExposure)
-						s = "auto";
-					else
-						s = "manual";
-					delayBetweenImages(CG, myRaspistillSetting.shutter_us, s);
-				}
+					s = "manual";
+				delayBetweenImages(CG, myRaspistillSetting.shutter_us, s);
 			}
 			else
 			{

--- a/src/include/mode_mean.h
+++ b/src/include/mode_mean.h
@@ -40,8 +40,6 @@ struct modeMeanSetting {
 
 	double const shuttersteps = 6.0;		// shuttersteps
 	int const historySize	= 3;			// Number of last images for mean target calculation.
-	int quickstart			= 10;			// Shorten delay between captures for this many images.
-											// to help get us to a good exposure quicker.
 	double mean_p0 = DEFAULT_MEAN_P0;		// ExposureChange (Steps) = p0 + p1 * diff + (p2*diff)^2
 	double mean_p1 = DEFAULT_MEAN_P1;
 	double mean_p2 = DEFAULT_MEAN_P2;

--- a/src/mode_mean.cpp
+++ b/src/mode_mean.cpp
@@ -299,11 +299,6 @@ void aegGetNextExposureSettings(config * cg,
 		Log(3, "  > ++++++++++ Prior image mean good - no changes needed, mean=%1.3f, target mean=%1.3f threshold=%1.3f\n",
 			cg->lastMean, currentModeMeanSetting.meanValue, currentModeMeanSetting.mean_threshold);
 		cg->goodLastExposure = true;
-		if (currentModeMeanSetting.quickstart > 0)
-		{
-			currentModeMeanSetting.quickstart = 0;		// Got a good exposure - turn quickstart off if on
-			Log(4, "  >> Disabling quickstart\n");
-		}
 	}
 
 	// Make sure exposureLevel is within min - max range.
@@ -365,10 +360,6 @@ void aegGetNextExposureSettings(config * cg,
 
 	//#############################################################################################################
 	// prepare for the next measurement
-	if (currentModeMeanSetting.quickstart > 0) {
-		currentModeMeanSetting.quickstart--;
-	}
-	// Exposure gilt fuer die naechste Messung
 	MeanCnt++;
 	exposureLevelHistory[MeanCnt % currentModeMeanSetting.historySize] = currentModeMeanSetting.exposureLevel;
 


### PR DESCRIPTION
The RPi-specific "quickstart" did the same thing as the generic "SkipFrames", but SkipFrames is configurable by users for day and night, and "quickstart" wasn't.  Further, "quickstart" saved the images then slept a second, messing up the timelapse.