### PR TITLE
options.json.repo: use "rotation_display"

### DIFF
--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -573,7 +573,7 @@
 "options" : [
 	"rotation_values"
 ],
-"display" : 0,
+"display" : "rotation_display",
 "advanced" : 0
 },
 {


### PR DESCRIPTION
ZWO camera's don't support rotation, so need the "display" placeholder to be "rotation_display".