### PR TITLE
allsky_common.cpp: ignore cameramodel

### DIFF
--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -1881,6 +1881,7 @@ bool getCommandLineArguments(config *cg, int argc, char *argv[])
 			strcmp(a, "usedarkframes") == 0 ||
 			strcmp(a, "uselogin") == 0 ||
 			strcmp(a, "cameratype") == 0 ||
+			strcmp(a, "cameramodel") == 0 ||
 			strcmp(a, "showusb") == 0 ||
 			strcmp(a, "alwaysshowadvanced") == 0
 			)


### PR DESCRIPTION
It was recently added