### PR TITLE
config.sh.repo: exit if settings file not found

### DIFF
--- a/config_repo/config.sh.repo
+++ b/config_repo/config.sh.repo
@@ -190,10 +190,10 @@ UHUBCTL_PORT=2
 # ================ DO NOT CHANGE ANYTHING BELOW THIS LINE ================
 END_OF_USER_SETTINGS="true"		# During upgrades, stop looking for variables here.
 
-CAMERA_TYPE=""
+CAMERA_TYPE=""		# Set during installation
 if [ "${CAMERA_TYPE}" = "" ]; then
-	echo -e "${RED}ERROR: Please set 'Camera Type' in the WebUI.${NC}"
-	sudo systemctl stop allsky
+	echo -e "${RED}${ME}: ERROR: Please set 'Camera Type' in the WebUI.${NC}"
+	sudo systemctl stop allsky > /dev/null 2>&1
 	exit ${EXIT_ERROR_STOP}
 fi
 
@@ -204,14 +204,19 @@ else
 	CAPTURE_SAVE_DIR="${IMG_DIR}"
 fi
 
-CAMERA_SETTINGS="${ALLSKY_CONFIG}/settings.json"
+SETTINGS_FILE=""		# Set during installation
+if [[ ! -f ${SETTINGS_FILE} ]]; then
+	echo -e "${RED}${ME}: ERROR: Settings file '${SETTINGS_FILE}' not found!${NC}"
+	sudo systemctl stop allsky > /dev/null 2>&1
+	exit ${EXIT_ERROR_STOP}
+fi
 
 # Simple way to get a setting that hides the details.
 function settings()
 {
-	j="$(jq -r "${1}" "${CAMERA_SETTINGS}")" && echo "${j}" && return
+	j="$(jq -r "${1}" "${SETTINGS_FILE}")" && echo "${j}" && return
 	echo "${ME}: running as $(id --user --name), unable to get json value for '${1}';" >&2
-	ls -l "${CAMERA_SETTINGS}" >&2
+	ls -l "${SETTINGS_FILE}" >&2
 }
 
 # Get the name of the file the websites will look for, and split into name and extension.


### PR DESCRIPTION
* During installation, if the settings file isn't found we get several confusing error messages from the settings() function.  Checking for existence of the file first allows us to produce a useful error message.
* To be consistent with other scripts, renamed the variable from CAMERA_SETTINGS to SETTINGS_FILE since it has more than just camera settings.