### PR TITLE
Add support for Google Cloud Storage uploads

### DIFF
--- a/config_repo/ftp-settings.sh.repo
+++ b/config_repo/ftp-settings.sh.repo
@@ -15,6 +15,8 @@
 	#		See the section for scp PROTOCOL below.   NOTE: "scp" PROTOCOL IS NOT IMPLEMENTED YET.
 	#  "S3"		uploads to an Amazon Web Services (AWS) server.
 	#		See the "S3 PROTOCOL only" section below.
+	#  "gcs"	uploads to an Google Cloud Storage (GCS) bucket.
+	#		See the "GCS PROTOCOL only" section below.
 PROTOCOL=""
 
 
@@ -103,9 +105,26 @@ AWS_CLI_DIR="/home/pi/.local/bin"
 S3_BUCKET="allskybucket"
 
 	# S3_ACL is set to private by default.
-	# If you want to serve your uploaded files vis http(s), change S3_ACL to "public-read".  
+	# If you want to serve your uploaded files vis http(s), change S3_ACL to "public-read".
 	# You will need to ensure the S3 bucket policy is configured to allow public access to
 	# objects with a public-read ACL.
 	# You may need to set a CORS policy in S3 if the files are to be accessed by
 	# Javascript from a different domain.
 S3_ACL="private"
+
+############### GCS PROTOCOL only:
+	# You will need to install the gsutil command, which is part of the Google Cloud SDK. See installation instructions at https://cloud.google.com/storage/docs/gsutil_install
+	# By default we expect the gsutil command to be found in /usr/bin.
+	# Make sure you authenticate the cli tool with the correct user as well.
+
+	# The directory where the gsutil command can be found. If you install through the deb package it's in the normal /usr/bin.
+GCS_CLI_DIR="/usr/bin"
+
+	# Name of the GCS bucket where the files are uploaded.
+GCS_BUCKET="allskybucket"
+
+	# GCS_ACL applies an access control rules to the uploaded files.
+	# It is set to `private` by default.
+	# You can use any one of the predefined acl rules found at https://cloud.google.com/storage/docs/access-control/lists#predefined-acl
+	# To access files over https, you can set it to `publicRead`.
+GCS_ACL="private"

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -114,6 +114,13 @@ if [[ "${PROTOCOL}" == "s3" ]] ; then
 	${AWS_CLI_DIR}/aws s3 cp "${FILE_TO_UPLOAD}" s3://${S3_BUCKET}${REMOTE_DIR} --acl ${S3_ACL} > "${LOG}"
 	RET=$?
 
+elif [[ ${PROTOCOL} == "gcs" ]] ; then
+	if [ "${SILENT}" = "false" ] && [ "${ALLSKY_DEBUG_LEVEL}" -ge 3 ]; then
+		echo "${ME}: Uploading ${FILE_TO_UPLOAD} to gcs ${GCS_BUCKET}/${REMOTE_DIR}"
+	fi
+	"${GCS_CLI_DIR}/gsutil" cp -a "${GCS_ACL}" "${FILE_TO_UPLOAD}" "gs://${GCS_BUCKET}${REMOTE_DIR}" > "${LOG}"
+	RET=$?
+
 elif [[ ${PROTOCOL} == "local" ]] ; then
 	if [ "${SILENT}" = "false" -a "${ALLSKY_DEBUG_LEVEL}" -ge 3 ]; then
 		echo "${ME}: Copying ${FILE_TO_UPLOAD} to ${REMOTE_DIR}/${DESTINATION_FILE}"


### PR DESCRIPTION
Supports GCS uploads throught the `gsutil` tool. Adds the relevant configuration options as well as documentation for how to configure and install the dependencies.