### PR TITLE
variables.sh: return 0 on success

### DIFF
--- a/variables.sh
+++ b/variables.sh
@@ -112,3 +112,5 @@ if [ "${ALLSKY_VARIABLE_SET}" = "" ]; then
 	# shellcheck disable=SC1090
 	[ -f "${ALLSKY_CONFIG}/uservariables.sh" ] && source "${ALLSKY_CONFIG}/uservariables.sh"
 fi
+
+return 0


### PR DESCRIPTION
So scripts that do a `source variables.sh || exit 1` work