### PR TITLE
camera_settings.php: "advanced" bug fix

### DIFF
--- a/html/includes/camera_settings.php
+++ b/html/includes/camera_settings.php
@@ -352,7 +352,7 @@ function toggle_advanced()
 
 					echo "</td>";
 					if ($type == "widetext")
-						echo "</tr><tr class='rowSeparator'><td></td>";
+						echo "</tr><tr class='rowSeparator $advClass' style='$advStyle'><td></td>";
 					echo "<td>$nullOKmsg$description</td>";
 				}
 				echo "</tr>";


### PR DESCRIPTION
It wasn't displaying "widetext" fields correctly when not showing advanced options