### PR TITLE
copy_notification_image.sh: copy to WEB_IMAGE_DIR

### DIFF
--- a/scripts/copy_notification_image.sh
+++ b/scripts/copy_notification_image.sh
@@ -151,7 +151,7 @@ if [ "${IMG_UPLOAD}" = "true" ] ; then
 	if [ ${ALLSKY_DEBUG_LEVEL} -ge 2 ]; then
 		echo -e "${ME}: Uploading $(basename "${NOTIFICATION_FILE}")"
 	fi
-	"${ALLSKY_SCRIPTS}/upload.sh" --wait --silent "${UPLOAD_FILE}" "${IMAGE_DIR}" "${FULL_FILENAME}" "NotificationImage"
+	"${ALLSKY_SCRIPTS}/upload.sh" --wait --silent "${UPLOAD_FILE}" "${IMAGE_DIR}" "${FULL_FILENAME}" "NotificationImage" "${WEB_IMAGE_DIR}"
 	RET=$?
 
 	# If we created a temporary copy, delete it.


### PR DESCRIPTION
All notification images should go to the remote website as well as the local one, if they exist.