### PR TITLE
Allow recreating allskyDefines.inc

### DIFF
--- a/html/dist/css/custom.css
+++ b/html/dist/css/custom.css
@@ -395,10 +395,8 @@ select {
 .dark .btn-black { border-color: #ffffff; }
 
 /* Error messages */
-.errorMsg {
-	color: red;
-	font-size: 125%;
-}
+.errorMsg, .errorMsgBig { color: red; font-size: 125%; }
+.errorMsgBig { font-size: 200%; }
 
 .thumb { width: 100px; margin: 0 1px 1px 0; }
 .left { float: left; }

--- a/html/includes/functions.php
+++ b/html/includes/functions.php
@@ -8,7 +8,18 @@
 */
 
 // Sets all the define() variables.
-require 'allskyDefines.inc';
+$defs = 'allskyDefines.inc';
+if (! file_exists("includes/" . $defs)) {
+	echo "<div style='font-size: 200%;'>";
+	echo "<p style='color: red'>";
+	echo "The installation of the WebUI is incomplete.<br>";
+	echo "Please run the following from the 'allsky' directory:";
+	echo "</p>";
+	echo "<code>   ./install.sh --function create_webui_defines</code>";
+	echo "</div>";
+	exit;
+}
+require $defs;
 
 $status = null;		// Global pointer to status messages
 $image_name=null; $delay=null; $daydelay=null; $nightdelay=null; $darkframe=null; $useLogin=null;

--- a/install.sh
+++ b/install.sh
@@ -123,20 +123,10 @@ select_camera_type() {
 }
 
 
-# Save the camera capabilities and use them to set the WebUI min, max, and defaults.
-# This will error out and exit if no camera installed,
-# otherwise it will determine what capabilities the connected camera has,
-# then create an "options" file specific to that camera.
-# It will also create a default "settings" file.
-save_camera_capabilities() {
-	if [[ -z ${CAMERA_TYPE} ]]; then
-		display_msg error "INTERNAL ERROR: CAMERA_TYPE not set in save_camera_capabilities()."
-		return 1
-	fi
-
+# Create the file that defines the WebUI variables.
+create_webui_defines() {
 	display_msg progress "Modifying locations for WebUI."
 	FILE="${ALLSKY_WEBUI}/includes/allskyDefines.inc"
-
 	sed		-e "s;XX_ALLSKY_HOME_XX;${ALLSKY_HOME};" \
 			-e "s;XX_ALLSKY_CONFIG_XX;${ALLSKY_CONFIG};" \
 			-e "s;XX_ALLSKY_SCRIPTS_XX;${ALLSKY_SCRIPTS};" \
@@ -151,6 +141,19 @@ save_camera_capabilities() {
 			-e "s;XX_RASPI_CONFIG_XX;${ALLSKY_CONFIG};" \
 		"${REPO_WEBUI_DEFINES_FILE}"  >  "${FILE}"
 		chmod 644 "${FILE}"
+}
+
+
+# Save the camera capabilities and use them to set the WebUI min, max, and defaults.
+# This will error out and exit if no camera installed,
+# otherwise it will determine what capabilities the connected camera has,
+# then create an "options" file specific to that camera.
+# It will also create a default "settings" file.
+save_camera_capabilities() {
+	if [[ -z ${CAMERA_TYPE} ]]; then
+		display_msg error "INTERNAL ERROR: CAMERA_TYPE not set in save_camera_capabilities()."
+		return 1
+	fi
 
 	# The web server needs to be able to create and update file in ${ALLSKY_CONFIG}
 	chmod 775 "${ALLSKY_CONFIG}"
@@ -173,7 +176,6 @@ save_camera_capabilities() {
 	"${ALLSKY_SCRIPTS}/makeChanges.sh" ${FORCE} --cameraTypeOnly ${DEBUG_ARG} \
 		"cameraType" "Camera Type" "${CAMERA_TYPE}"
 	RET=$?
-
 	if [ ${RET} -ne 0 ]; then
 		if [ ${RET} -eq ${EXIT_NO_CAMERA} ]; then
 			MSG="No camera was found; one must be connected and working for the installation to succeed.\n"
@@ -805,6 +807,7 @@ if [[ ${FUNCTION} != "" ]]; then
 	fi
 
 	${FUNCTION}
+	display_msg progress "\n${FUNCTION} completed.\n"
 	exit 0
 fi
 


### PR DESCRIPTION
If a user accidently removes the contents of the `allsky/html` directory (like I did), they can grab it from GitHub, but need to run the installation script to create `allsky/html/includes/allskyDefines.inc`