### PR TITLE
Allow multiple levels of verbosity in update website config.sh

### DIFF
--- a/scripts/updateWebsiteConfig.sh
+++ b/scripts/updateWebsiteConfig.sh
@@ -34,7 +34,7 @@ function usage_and_exit()
 	else
 		C="${wERROR}"
 	fi
-	echo -e "${C}Usage: ${ME} [--help] [--debug] [--silent] [--config file] key label new_value [...]${wNC}" >&2
+	echo -e "${C}Usage: ${ME} [--help] [--debug] [--verbosity silent|summary|verbose] [--config file] key label new_value [...]${wNC}" >&2
 	echo "There must be a multiple of 3 arguments." >&2
 	exit ${RET}
 }
@@ -42,7 +42,7 @@ function usage_and_exit()
 OK="true"
 HELP="false"
 DEBUG="false"
-SILENT="false"
+VERBOSITY="summary"
 CONFIG_FILE=""
 while [ $# -gt 0 ]; do
 	ARG="${1}"
@@ -53,8 +53,9 @@ while [ $# -gt 0 ]; do
 		--debug)
 			DEBUG="true"
 			;;
-		--silent)
-			SILENT="true"
+		--verbosity)
+			VERBOSITY="${2}"
+			shift
 			;;
 		--config)
 			CONFIG_FILE="${2}"
@@ -81,20 +82,24 @@ done
 [[ $(($# % 3)) -ne 0 ]] && usage_and_exit 2
 
 if [[ ${CONFIG_FILE} != "" ]]; then
-	if [[ ! -f "${CONFIG_FILE}" ]]; then
+	if [[ ! -f ${CONFIG_FILE} ]]; then
 		echo -e "${wERROR}ERROR: Configuration file not found: '${CONFIG_FILE}'.${wNC}" >&2
 		exit 1
 	fi
+	LorR=""
 else
 	# Look for the configuration file.
 	CONFIG_FILE="${ALLSKY_WEBSITE_CONFIGURATION_FILE}"	# local website
-	if [ ! -f "${CONFIG_FILE}" ]; then
+	if [[ -f ${CONFIG_FILE} ]]; then
+		LorR="Local "
+	else
 		CONFIG_FILE="${ALLSKY_REMOTE_WEBSITE_CONFIGURATION_FILE}"	# remote website
 		if [ ! -f "${CONFIG_FILE}" ]; then
 			# Can't find the configuration file on the Pi or for remote.
 			echo -e "${wWARNING}WARNING: No configuration file found.${wNC}" >&2
 			exit 99
 		fi
+		LorR="Remote "
 	fi
 fi
 
@@ -138,7 +143,11 @@ else
 	# shellcheck disable=SC2124
 	S="${JQ_STRING[@]}"
 	if OUTPUT="$(jq "${S}" "${CONFIG_FILE}" 2>&1 > /tmp/x && mv /tmp/x "${CONFIG_FILE}")"; then
-		[ "${SILENT}" = "false" ] && echo -e "${wOK}${OUTPUT_MESSAGE}${wNC}"
+		if [[ ${VERBOSITY} == "verbose" ]]; then
+			echo -e "${wOK}${OUTPUT_MESSAGE}${wNC}"
+		elif [[ ${VERBOSITY} == "summary" ]]; then
+			echo -e "${wOK}${LorR}Allsky Website ${ALLSKY_WEBSITE_CONFIGURATION_NAME} UPDATED${wNC}"
+		fi		# nothing if "silent"
 	else
 		echo -e "${wERROR}ERROR: unable to update data in '${CONFIG_FILE}':${wNC}" >&2
 		echo "   ${OUTPUT}" >&2

--- a/website/install.sh
+++ b/website/install.sh
@@ -195,7 +195,7 @@ create_website_configuration_file() {
 		AURORAMAP="north"
 	fi
 
-	COMPUTER="$(sed --quiet -e 's/Raspberry //' -e '/^Model/ s/.*: // p' /proc/cpuinfo)"
+	COMPUTER="$(sed --quiet -e 's/Raspberry Pi/RPi/' -e '/^Model/ s/.*: // p' /proc/cpuinfo)"
 	CAMERA_MODEL="$(settings ".cameraModel")"
 	if [[ ${CAMERA_MODEL} == "null" ]]; then
 		CAMERA_MODEL=""
@@ -206,7 +206,7 @@ create_website_configuration_file() {
 
 	# There are some settings we can't determine, like LENS.
 	[[ ${DEBUG} == "true" ]] && display_msg debug "Calling updateWebsiteConfig.sh"
-	"${ALLSKY_SCRIPTS}/updateWebsiteConfig.sh" --silent ${DEBUG_ARG} \
+	"${ALLSKY_SCRIPTS}/updateWebsiteConfig.sh" --verbosity silent ${DEBUG_ARG} \
 		--config "${FILE_TO_CREATE}" \
 		config.imageName		"imageName"		"${IMAGE_NAME}" \
 		config.latitude			"latitude"		"${LATITUDE}" \


### PR DESCRIPTION
When called via the WebUI, we just want a "configuration file was update" message rather than a separate message for every field that was update, which no other updates do.