### PR TITLE
Execute upload.sh as pi

### DIFF
--- a/config_repo/sudoers.repo
+++ b/config_repo/sudoers.repo
@@ -27,5 +27,6 @@ www-data ALL=(ALL) NOPASSWD:/usr/bin/vcgencmd
 www-data ALL=(ALL) NOPASSWD:XX_ALLSKY_SCRIPTS_XX/postData.sh
 www-data ALL=(ALL) NOPASSWD:/usr/sbin/ifconfig
 www-data ALL=(ALL) NOPASSWD:/usr/bin/truncate
+www-data ALL=(ALL) NOPASSWD:XX_ALLSKY_SCRIPTS_XX/upload.sh
 www-data ALL=(ALL) NOPASSWD:XX_ALLSKY_SCRIPTS_XX/makeChanges.sh
 www-data ALL=(ALL) NOPASSWD:/usr/bin/date

--- a/html/includes/save_file.php
+++ b/html/includes/save_file.php
@@ -46,7 +46,7 @@ if ($msg == "") {
 		// name to NOT include that string.
 		$remoteName = str_replace("remote_", "", basename($file));
 		$cmd = ALLSKY_SCRIPTS . "/upload.sh --silent '$file' '$imageDir' '$remoteName' 'remote_file'";
-		exec("$cmd 2>&1", $output, $return_val);
+		exec("sudo -u " . ALLSKY_OWNER . " $cmd 2>&1", $output, $return_val);
 		if ($return_val == 0) {
 			$msg = "$file saved and sent to $remoteHost as $remoteName.";
 		} else {


### PR DESCRIPTION
If a user updates a remote file in the WebUI at the same time Allsky is uploading a file, the WebUI action won't work since the upload pid fix exists and isn't writeable by the web server.
This fix makes the WebUI run the "upload.sh" file as pi.