### PR TITLE
Fix for udev permissions on installation

### DIFF
--- a/config_repo/Makefile
+++ b/config_repo/Makefile
@@ -106,6 +106,7 @@ install: createDirs $(CONFIGFILES)
 	@install -D -m 0644 allsky.logrotate.repo $(DESTDIR)$(sysconfdir)/logrotate.d/allsky
 	@install -D -m 0644 allsky.rsyslog.repo $(DESTDIR)$(sysconfdir)/rsyslog.d/allsky.conf
 	@udevadm control -R
+	@udevadm trigger
 	@echo `date +%F\ %R:%S` Setting allsky to auto start...
 	@if [ -e /etc/xdg/lxsession/LXDE-pi/autostart ]; then \
 	  sed -i '/allsky.sh/d' /etc/xdg/lxsession/LXDE-pi/autostart; fi


### PR DESCRIPTION
Force a "udevadm trigger" when AllSky is first installed. This is to ensure that the asi rules are recognised by AllSky as the ZWO capture routine is required to run as part of the installation. 
Without this the user will get permission errors when AllSky attempts to get the camera configuration