### PR TITLE
index.html: test with no type for icon

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -8,7 +8,7 @@
 	<script src="documentation.js" type="application/javascript"></script>
 	<link href="css/light.css" rel="stylesheet">
 	<link href="css/documentation.css" rel="stylesheet">
-	<link href="documentation-favicon.ico" rel="shortcut icon" type="image/png">
+	<link href="documentation-favicon.ico" rel="shortcut icon">
 
 	<meta name="description" content="Documentation for Allsky">
 	<title>AllSky Documentation</title>


### PR DESCRIPTION
When viewing the GitHub page, the shortcut icon isn't downloaded.  See if removing the "type=" attribute fixes this.