### PR TITLE
Restore lat and long

### DIFF
--- a/config_repo/config.sh.repo
+++ b/config_repo/config.sh.repo
@@ -222,7 +222,7 @@ fi
 # Simple way to get a setting that hides the details.
 function settings()
 {
-	j="$(jq -r "${1}" "${SETTINGS_FILE}")" && echo "${j}" && return
+	j="$(jq -r "${1}" "${2:-${SETTINGS_FILE}}")" && echo "${j}" && return
 	echo "${ME}: running as $(id --user --name), unable to get json value for '${1}';" >&2
 	ls -l "${SETTINGS_FILE}" >&2
 }

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ fi
 ME="$(basename "${BASH_ARGV0}")"
 
 source "${ALLSKY_HOME}/variables.sh" || exit 1
+source "${ALLSKY_CONFIG}/config.sh" || exit 1
 source "${ALLSKY_SCRIPTS}/functions.sh" || exit 1
 
 if [[ ${EUID} -eq 0 ]]; then
@@ -594,6 +595,7 @@ create_allsky_log() {
 	sudo chgrp ${ALLSKY_GROUP} "${ALLSKY_LOG}"
 }
 
+
 # If the user wanted to restore files from a prior version of Allsky, do that.
 restore_prior_files() {
 	if [[ -z ${PRIOR_ALLSKY} ]]; then
@@ -682,6 +684,7 @@ restore_prior_files() {
 			cp "${PRIOR_CONFIG_DIR}/settings.json" "${ALLSKY_CONFIG}"
 			RESTORED_PRIOR_SETTINGS_FILE=true
 		fi
+		# else, what the heck?  Their prior version is "new" but they don't have a settings file?
 	else
 		# settings file is old style in ${OLD_RASPAP_DIR}.
 		if [[ ${CAMERA_TYPE} == "ZWO" ]]; then
@@ -692,6 +695,13 @@ restore_prior_files() {
 		SETTINGS="${OLD_RASPAP_DIR}/settings_${CT}.json"
 		if [[ -f ${SETTINGS} ]]; then
 			SETTINGS_MSG="\n\nYou also need to transfer your old settings to the WebUI.\nUse ${SETTINGS} as a guide.\n"
+			# Restore the latitude and longitude so Allsky can start after reboot.
+			LAT="$(settings .latitude "${SETTINGS}")"
+			LONG="$(settings .longitude "${SETTINGS}")"
+			"${ALLSKY_SCRIPTS}/updateWebsiteConfig.sh" ${DEBUG_ARG} \
+				"config.latitude" "Latitude" "${LAT}" \
+				"config.longitude" "Longitude" "${LONG}"
+			display_msg --log progress "Prior latitude and longitude saved."
 		fi
 
 		# If we ever automate migrating settings, this next statement should be deleted.
@@ -925,3 +935,4 @@ fi
 ask_reboot
 
 exit 0
+


### PR DESCRIPTION
Only needed for "old" style prior Allsky, and only if we can find the old settings file.
Doing this will allow Allsky to start after the reboot.