### PR TITLE
functions.php: fix

### DIFF
--- a/html/includes/functions.php
+++ b/html/includes/functions.php
@@ -863,8 +863,6 @@ function getVariableOrDefault($a, $v, $d) {
 	if (isset($a[$v])) {
 		$value = $a[$v];
 		if (gettype($value) === "boolean" && $value == "") return 0;
-		if (is_string($value) and $value === '' and $d !=='') return $d;
-		if (is_null($value) and !is_null($d)) return $d;
 		return $value;
 	} else if (gettype($d) === "boolean" && $d == "") {
 		return 0;;
@@ -872,6 +870,5 @@ function getVariableOrDefault($a, $v, $d) {
 
 	return($d);
 }
-
 
 ?>


### PR DESCRIPTION
Turns out, displaying the default for empty values isn't good.  The settings file may have "" but the user sees the default.  The Allsky Settings page should always display what's in (or not in) the settings file.  Will do a different PR to not allow blank settings if they are required.