### PR TITLE
Indicate optional settings

### DIFF
--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -400,11 +400,12 @@
 {
 "name" : "config",
 "default" : "[none]",
-"description" : "Configuration file to use for settings.",
+"description" : "Optional configuration file to use for settings.",
 "label" : "Configuration File",
 "type" : "widetext",
 "display" : 1,
 "checkchanges" : 1,
+"optional" : 1,
 "advanced" : 1
 },
 {
@@ -861,6 +862,7 @@
 "label" : "Text Overlay",
 "type" : "widetext",
 "display" : 1,
+"optional" : 1,
 "advanced" : 0
 },
 {
@@ -871,6 +873,7 @@
 "type" : "widetext",
 "display" : 1,
 "checkchanges" : 1,
+"optional" : 1,
 "advanced" : 0
 },
 {
@@ -1037,6 +1040,7 @@
 "type" : "widetext",
 "display" : 1,
 "checkchanges" : 1,
+"optional" : 1,
 "advanced" : 0
 },
 {
@@ -1047,6 +1051,7 @@
 "type" : "widetext",
 "display" : 1,
 "checkchanges" : 1,
+"optional" : 1,
 "advanced" : 0
 },
 {
@@ -1057,6 +1062,7 @@
 "type" : "widetext",
 "display" : 1,
 "checkchanges" : 1,
+"optional" : 1,
 "advanced" : 0
 },
 {
@@ -1067,6 +1073,7 @@
 "type" : "text",
 "display" : 1,
 "checkchanges" : 1,
+"optional" : 1,
 "advanced" : 0
 },
 {
@@ -1077,6 +1084,7 @@
 "type" : "widetext",
 "display" : 1,
 "checkchanges" : 1,
+"optional" : 1,
 "advanced" : 0
 },
 {
@@ -1087,6 +1095,7 @@
 "type" : "text",
 "display" : 1,
 "checkchanges" : 1,
+"optional" : 1,
 "advanced" : 0
 },
 {
@@ -1097,6 +1106,7 @@
 "type" : "widetext",
 "display" : 1,
 "checkchanges" : 1,
+"optional" : 1,
 "advanced" : 0
 },
 {

--- a/html/includes/createAllskyOptions.php
+++ b/html/includes/createAllskyOptions.php
@@ -289,6 +289,7 @@ if ($repo_array === null) {
 	// options			[array with 1 or more entries] (only if "type" == "select")
 	// display			[0/1]
 	// checkchanges		[0/1]
+	// optional			[0/1]
 	// nullOK			[0/1]
 	// advanced 		[0/1]	(last, so no comma after it)
 
@@ -355,6 +356,7 @@ foreach ($repo_array as $repo) {
 		add_non_null_field($repo, "options", $name);
 		add_non_null_field($repo, "display", $name);
 		add_non_null_field($repo, "checkchanges", $name);
+		add_non_null_field($repo, "optional", $name);
 		add_non_null_field($repo, "nullOK", $name);
 		add_non_null_field($repo, "advanced", $name);
 	$options_str .= "},\n";


### PR DESCRIPTION
This is the beginning of the capability to have the WebUI check for required fields that are empty.  Since most fields are required, an "optional: true" field is added.  If the "optional" field is missing then "false" is assumed.  In theory, all the required fields could have "optional: false", but that just clutters things.

The majority of the work will be done in allskySettings.php via a separate PR.