### PR TITLE
fix to support lite version of raspberry OS

### DIFF
--- a/config_repo/allsky.service.repo
+++ b/config_repo/allsky.service.repo
@@ -1,6 +1,6 @@
 [Unit]
 Description=All Sky Camera
-After=multi-user.target
+After=network.target
 
 [Service]
 User=pi


### PR DESCRIPTION
The lite version of the OS never starts the allsky.service since it never gets to multiuser mode.  by changing the After target to network.target this project will work both on a full desktop install of raspberry pi OS and the lite version.  This change was tested on both and worked across multiple reboots on both versions.