### PR TITLE
Change allsky logging to ensure logs only written to allsky log files

### DIFF
--- a/config_repo/allsky.rsyslog.repo
+++ b/config_repo/allsky.rsyslog.repo
@@ -1,2 +1,5 @@
-local5.*    /var/log/allsky.log
-local6.*    /var/log/allskyperiodic.log
+if $programname == 'allsky' then /var/log/allsky.log
+&stop
+
+if $programname == 'allskperiodic' then /var/log/allskyperiodic.log
+& stop

--- a/config_repo/allsky.service.repo
+++ b/config_repo/allsky.service.repo
@@ -5,7 +5,7 @@ After=multi-user.target
 [Service]
 User=XX_ALLSKY_OWNER_XX
 ExecStart=XX_ALLSKY_HOME_XX/allsky.sh
-SyslogFacility=local5
+SyslogIdentifier=allsky
 Restart=on-success
 RestartSec=2
 ; exit status 100 and higher mean a fatal error the user needs to fix, so don't restart

--- a/config_repo/allskyperiodic.service.repo
+++ b/config_repo/allskyperiodic.service.repo
@@ -5,7 +5,7 @@ After=multi-user.target
 [Service]
 User=XX_ALLSKY_OWNER_XX
 ExecStart=XX_ALLSKY_HOME_XX/scripts/periodic.sh
-SyslogFacility=local6
+SyslogIdentifier=allskperiodic
 Restart=on-success
 RestartSec=5
 ; exit status 100 and higher mean a fatal error the user needs to fix, so don't restart


### PR DESCRIPTION
Modified the services and rsyslog config to write to specific log files. This will prevent the AllSky log message sbeing duplicated in syslog and messages.

Log rotation has remained the same 