### PR TITLE
Fixes to support more RPi cameras

### DIFF
--- a/src/ASI_functions.cpp
+++ b/src/ASI_functions.cpp
@@ -1154,7 +1154,7 @@ static bool checkBin(long b, ASI_CAMERA_INFO ci, char const *field)
 			break;
 	}
 	if (! ok)
-		Log(0, "*** ERROR: %s bin of %ldx%ld not supported by camera %s, sensor %s.\n", field, b, b, ci.Name, ci.Module);
+		Log(0, "*** ERROR: %s bin of %ldx%ld not supported by camera %s.\n", field, b, b, ci.Name);
 
 	return(ok);
 }
@@ -1547,4 +1547,3 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 
 	return(ok);
 }
-

--- a/src/include/allsky_common.h
+++ b/src/include/allsky_common.h
@@ -133,7 +133,7 @@ struct config {			// for configuration variables
 	// passed around.
 
 	// Camera number, type and model
-	int cameraNumber					= 0;			// 0 to number-of-cameras-attached minus 1
+	int cameraNumber					= NOT_SET;		// 0 to number-of-cameras-attached minus 1
 	cameraType ct						= ctRPi;
 	char const *cm						= "";
 


### PR DESCRIPTION
Fix to return a cameraNumber thats an index into the array of control values for the camera.  It used to always return an index into the 1st entry in the array.