### PR TITLE
WebUI bug fix: $config overwrites prior $config

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -101,8 +101,8 @@ $remoteWebsiteVersion = "";
 if (file_exists(ALLSKY_WEBSITE_REMOTE_CONFIG)) {
 	$a_str = file_get_contents(ALLSKY_WEBSITE_REMOTE_CONFIG, true);
 	$a_array = json_decode($a_str, true);
-	$config = getVariableOrDefault($a_array, 'config', '');
-	$remoteWebsiteVersion = getVariableOrDefault($config, 'AllskyWebsiteVersion', '<span class="errorMsg">[unknown]</span>');
+	$c = getVariableOrDefault($a_array, 'config', '');
+	$remoteWebsiteVersion = getVariableOrDefault($c, 'AllskyWebsiteVersion', '<span class="errorMsg">[unknown]</span>');
 }
 ?>
 


### PR DESCRIPTION
The $config for the remote Website overwrites $config used to set global variables.