### PR TITLE
periodic.sh: exit 0 when signal is sent

### DIFF
--- a/scripts/periodic.sh
+++ b/scripts/periodic.sh
@@ -7,7 +7,7 @@ source "${ALLSKY_HOME}/variables.sh"		|| exit 99
 # shellcheck disable=SC1090,SC1091
 source "${ALLSKY_HOME}/config/config.sh"	|| exit 99
 
-trap "exit" SIGTERM SIGINT
+trap "exit 0" SIGTERM SIGINT
 
 cd "${ALLSKY_SCRIPTS}" || exit 99
 


### PR DESCRIPTION
This causes the service to exit gracefully rather than with 130 (128 + SIGINT (2)) or 143 (128 + SIGTERM (15)).