### PR TITLE
Pass only non-default arguments

### DIFF
--- a/src/ASI_functions.cpp
+++ b/src/ASI_functions.cpp
@@ -1302,6 +1302,7 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 	ret = getControlCapForControlType(cg->cameraNumber, ASI_FLIP, &cc);
 	if (ret == ASI_SUCCESS)
 	{
+		cg->defaultFlip = cc.DefaultValue;
 		if (cg->flip == NOT_CHANGED)
 			cg->flip = cc.DefaultValue;
 		else
@@ -1312,6 +1313,7 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 	}
 
 	// libcamera only supports 0 and 180 degree rotation
+	cg->defaultRotation = 0;
 	if (cg->rotation != 0)
 	{
 		if (cg->ct == ctRPi && cg->isLibcamera)
@@ -1352,10 +1354,11 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 	}
 
 	validateLong(&cg->debugLevel, 0, 4, "Debug Level", true);
+
+	// Overlay-related arguments
 	validateLong(&cg->overlay.extraFileAge, 0, NO_MAX_VALUE, "Max Age Of Extra", true);
 	validateLong(&cg->overlay.fontnumber, 0, 8-1, "Font Name", true);
 	validateLong(&cg->overlay.linenumber, 0, sizeof(cg->overlay.linetype)-1, "Font Smoothness", true);
-
 	if (cg->overlay.fc != NULL && sscanf(cg->overlay.fc, "%d %d %d",
 			&cg->overlay.fontcolor[0], &cg->overlay.fontcolor[1], &cg->overlay.fontcolor[2]) != 3)
 		Log(-1, "%s*** WARNING: Not enough font color parameters: '%s'%s\n", c(KRED), cg->overlay.fc, c(KNRM));
@@ -1363,6 +1366,7 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 			&cg->overlay.smallFontcolor[0], &cg->overlay.smallFontcolor[1], &cg->overlay.smallFontcolor[2]) != 3)
 		Log(-1, "%s*** WARNING: Not enough small font color parameters: '%s'%s\n", c(KRED), cg->overlay.sfc, c(KNRM));
 
+	cg->defaultBin = 1;
 	if (! checkBin(cg->dayBin, ci, "Daytime Binning"))
 		ok = false;
 	if (! checkBin(cg->nightBin, ci, "Nighttime Binning"))
@@ -1394,6 +1398,7 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 	ret = getControlCapForControlType(cg->cameraNumber, ASI_GAIN, &cc);
 	if (ret == ASI_SUCCESS)
 	{
+		cg->defaultGain = cc.DefaultValue;
 		cg->cameraMinGain = cc.MinValue;		// used elsewhere
 		if (cg->dayGain == NOT_CHANGED)
 			cg->dayGain = cc.DefaultValue;
@@ -1428,6 +1433,7 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 		ret = getControlCapForControlType(cg->cameraNumber, ASI_WB_R, &cc);
 		if (ret == ASI_SUCCESS)
 		{
+			cg->defaultWBR = cc.DefaultValue;
 			if (cg->dayWBR == NOT_CHANGED)
 				cg->dayWBR = cc.DefaultValue;
 			else
@@ -1444,6 +1450,7 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 		ret = getControlCapForControlType(cg->cameraNumber, ASI_WB_B, &cc);
 		if (ret == ASI_SUCCESS)
 		{
+			cg->defaultWBB = cc.DefaultValue;
 			if (cg->dayWBB == NOT_CHANGED)
 				cg->dayWBB = cc.DefaultValue;
 			else
@@ -1463,6 +1470,7 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 		ret = getControlCapForControlType(cg->cameraNumber, SATURATION, &cc);
 		if (ret == ASI_SUCCESS)
 		{
+			cg->defaultSaturation = cc.DefaultValue;
 			if (cg->saturation == NOT_CHANGED)
 				cg->saturation = cc.DefaultValue;
 			else
@@ -1475,6 +1483,7 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 		ret = getControlCapForControlType(cg->cameraNumber, CONTRAST, &cc);
 		if (ret == ASI_SUCCESS)
 		{
+			cg->defaultContrast = cc.DefaultValue;
 			if (cg->contrast == NOT_CHANGED)
 				cg->contrast = cc.DefaultValue;
 			else
@@ -1487,6 +1496,7 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 		ret = getControlCapForControlType(cg->cameraNumber, SHARPNESS, &cc);
 		if (ret == ASI_SUCCESS)
 		{
+			cg->defaultSharpness = cc.DefaultValue;
 			if (cg->sharpness == NOT_CHANGED)
 				cg->sharpness = cc.DefaultValue;
 			else
@@ -1555,3 +1565,4 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 
 	return(ok);
 }
+

--- a/src/ASI_functions.cpp
+++ b/src/ASI_functions.cpp
@@ -1232,13 +1232,16 @@ bool setDefaults(config *cg, ASI_CAMERA_INFO ci)
 
 	signal(SIGINT, IntHandle);
 	signal(SIGTERM, IntHandle);	// The service sends SIGTERM to end this program.
-	signal(SIGHUP, sig);		// xxxxxxxxxx TODO: Set up to re-read settings (we currently just restart).
+	signal(SIGHUP, IntHandle);		// SIGHUP means restart.
 
 	return(ok);
 }
 
 // If a value is currently NOT_CHANGED, the user didn't specify so use the default.
 // Validate the command-line settings.
+// For cameras that use an external application to take pictures,
+// set any default values specified by the user to IS_DEFAULT so we don't pass the
+// value to the external program.
 bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 {
 	ASI_ERROR_CODE ret;
@@ -1552,4 +1555,3 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 
 	return(ok);
 }
-

--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -243,7 +243,7 @@ void add_variables_to_command(config cg, char *cmd, timeval startDateTime)
 	// Since negative temperatures are valid, check against an impossible temperature.
 	// The temperature passed to us is 10 times the actual temperature so we can deal with
 	// integers with 1 decimal place, which is all we care about.
-	if (cg.lastSensorTemp != -999) {
+	if (cg.supportsTemperature && cg.lastSensorTemp != NOT_SET) {
 		snprintf(tmp, s, " TEMPERATURE_C=%d", (int)round(cg.lastSensorTemp));
 		strcat(cmd, tmp);
 		snprintf(tmp, s, " TEMPERATURE_F=%d", (int)round((cg.lastSensorTemp * 1.8) +32));
@@ -1976,7 +1976,7 @@ static char const *validateLatLong(
 		return(NULL);
 	}
 
-	Log(4, "validateLatLong(l=%s, positive=%c, negative=%c, savedLocation=%s, name=%s\n", l, positive,negative,savedLocation,name);
+	Log(4, "validateLatLong(l=%s, positive=%c, negative=%c, savedLocation=%s, name=%s)\n", l, positive,negative,savedLocation,name);
 	int len = strlen(l);
 	char direction = (char) toupper(l[len-1]);
 	if (direction == positive || direction == negative) {
@@ -2008,4 +2008,3 @@ bool validateLatitudeLongitude(config *cg)
 
 	return(ret);
 }
-

--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -1117,7 +1117,7 @@ void displaySettings(config cg)
 	printf("%s", c(KGRN));
 	printf("\nSettings:\n");
 
-	if (cg.ct == ctRPi)
+	if (cg.cmdToUse != NULL)
 		printf("   Command: %s\n", cg.cmdToUse);
 	printf("   Image Type: %s (%ld)\n", cg.sType, cg.imageType);
 	printf("   Resolution (before any binning): %ldx%ld\n", cg.width, cg.height);

--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -804,24 +804,24 @@ void closeUp(int e)
 }
 
 // Handle signals
-void sig(int i)
-{
-	if (i == SIGHUP)
-	{
-		// TODO: Restart rather than exit
-		Log(4, "Got signal to restart.\n");
-	}
-	else
-	{
-		Log(0, "Got unknown signal %d in sig().\n", i);
-	}
-	gotSignal = true;
-	closeUp(EXIT_RESTARTING);
-}
 void IntHandle(int i)
 {
 	gotSignal = true;
-	closeUp(EXIT_OK);
+	if (i == SIGHUP)
+	{
+		// TODO: Re-read configuration instead of restarting.
+		Log(4, "Got SIGHUP to restart.\n");
+		closeUp(EXIT_RESTARTING);
+	}
+	else if (i == SIGINT || i == SIGTERM)
+	{
+		closeUp(EXIT_OK);
+	}
+	else
+	{
+		Log(0, "Got unknown signal %d.\n", i);
+		closeUp(i);
+	}
 }
 
 

--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -808,6 +808,7 @@ void sig(int i)
 {
 	if (i == SIGHUP)
 	{
+		// TODO: Restart rather than exit
 		Log(4, "Got signal to restart.\n");
 	}
 	else
@@ -2007,3 +2008,4 @@ bool validateLatitudeLongitude(config *cg)
 
 	return(ret);
 }
+

--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -250,16 +250,18 @@ int RPicapture(config cg, cv::Mat *image)
 		command += " --awb auto";
 	}
 
-	if (cg.rotation != 0) {
+	if (cg.rotation != cg.defaultRotation) {
 		ss.str("");
 		ss << cg.rotation;
 		command += " --rotation " + ss.str();
 	}
 
-	if (cg.flip == 1 || cg.flip == 3)
-		command += " --hflip";		// horizontal flip
-	if (cg.flip == 2 || cg.flip == 3)
-		command += " --vflip";		// vertical flip
+	if (cg.flip != cg.defaultFlip) {
+		if (cg.flip == 1 || cg.flip == 3)
+			command += " --hflip";		// horizontal flip
+		if (cg.flip == 2 || cg.flip == 3)
+			command += " --vflip";		// vertical flip
+	}
 
 	if (cg.saturation != cg.defaultSaturation) {
 		ss.str("");

--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -218,7 +218,7 @@ int RPicapture(config cg, cv::Mat *image)
 			command += " --analoggain 1";	// 1 makes it autogain
 		}
 	}
-	else if (cg.currentGain != IS_DEFAULT)	// Is manual gain
+	else if (cg.currentGain != cg.defaultGain)	// Is manual gain
 	{
 		ss.str("");
 		ss << cg.currentGain;
@@ -243,7 +243,7 @@ int RPicapture(config cg, cv::Mat *image)
 		ss << cg.currentWBR << "," << cg.currentWBB;
 		if (! cg.isLibcamera)
 			command += " --awb off";
-		if (cg.currentWBR != IS_DEFAULT and cg.currentWBB != IS_DEFAULT)
+		if (cg.currentWBR != cg.defaultWBR || cg.currentWBB != cg.defaultWBB)
 			command += " --awbgains " + ss.str();
 	}
 	else {		// Use automatic white balance
@@ -261,25 +261,25 @@ int RPicapture(config cg, cv::Mat *image)
 	if (cg.flip == 2 || cg.flip == 3)
 		command += " --vflip";		// vertical flip
 
-	if (cg.saturation != IS_DEFAULT) {
+	if (cg.saturation != cg.defaultSaturation) {
 		ss.str("");
 		ss << cg.saturation;
 		command += " --saturation "+ ss.str();
 	}
 
-	if (cg.contrast != IS_DEFAULT) {
+	if (cg.contrast != cg.defaultContrast) {
 		ss.str("");
 		ss << cg.contrast;
 		command += " --contrast "+ ss.str();
 	}
 
-	if (cg.sharpness != IS_DEFAULT) {
+	if (cg.sharpness != cg.defaultSharpness) {
 		ss.str("");
 		ss << cg.sharpness;
 		command += " --sharpness "+ ss.str();
 	}
 
-	if (cg.currentBrightness != IS_DEFAULT) {
+	if (cg.currentBrightness != cg.defaultBrightness) {
 		ss.str("");
 		if (cg.isLibcamera)
 			// User enters -100 to 100.  Convert to -1.0 to 1.0.
@@ -289,11 +289,18 @@ int RPicapture(config cg, cv::Mat *image)
 		command += " --brightness " + ss.str();
 	}
 
-	if (cg.quality != IS_DEFAULT) {
+	if (cg.quality != cg.defaultQuality) {
 		ss.str("");
 		ss << cg.quality;
 		command += " --quality " + ss.str();
 	}
+
+	// Define char variable
+	char cmd[command.length() + 1];
+	// Convert command to character variable.
+	// Log without the LIBCAMERA_LOG..., which just confuses users.
+	strcpy(cmd, command.c_str());
+	Log(2, "  > Capture command: %s\n", cmd);
 
 	if (cg.isLibcamera)
 	{
@@ -307,13 +314,6 @@ int RPicapture(config cg, cv::Mat *image)
 			command += " 2> /dev/null";	// gets rid of a bunch of libcamera verbose messages
 		}
 	}
-
-	// Define char variable
-	char cmd[command.length() + 1];
-	// Convert command to character variable.
-	// Log without the LIBCAMERA_LOG..., which just confuses users.
-	strcpy(cmd, command.c_str());
-	Log(2, "  > Capture command: %s\n", cmd);
 
 	if (cg.isLibcamera)
 	{
@@ -335,8 +335,8 @@ int RPicapture(config cg, cv::Mat *image)
 }
 
 
-//-------------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------
 
 int main(int argc, char *argv[])
 {

--- a/src/include/allsky_common.h
+++ b/src/include/allsky_common.h
@@ -261,7 +261,14 @@ struct config {			// for configuration variables
 	struct HB HB;							// Histogram Box, ZWO only
 
 	// Default values used in multiple places, so get just once.
+	double defaultGain					= NOT_SET;
+	double defaultWBR					= NOT_SET;
+	double defaultWBB					= NOT_SET;
+	double defaultSaturation			= NOT_SET;
+	double defaultContrast				= NOT_SET;
+	double defaultSharpness				= NOT_SET;
 	long defaultBrightness				= NOT_SET;
+	int defaultQuality;					= NOT_SET;
 
 	// Current values - may vary between day and night
 	bool currentAutoExposure;
@@ -336,3 +343,4 @@ void delayBetweenImages(config, long, std::string);
 bool getCommandLineArguments(config *, int, char *[]);
 int displayNotificationImage(char const *);
 bool validateLatitudeLongitude(config *);
+

--- a/src/include/allsky_common.h
+++ b/src/include/allsky_common.h
@@ -261,6 +261,10 @@ struct config {			// for configuration variables
 	struct HB HB;							// Histogram Box, ZWO only
 
 	// Default values used in multiple places, so get just once.
+	// Only include variables that we pass to the capture routine/program.
+	int defaultFlip						= NOT_SET;
+	int defaultRotation					= NOT_SET;
+	int	defaultBin						= NOT_SET;
 	double defaultGain					= NOT_SET;
 	double defaultWBR					= NOT_SET;
 	double defaultWBB					= NOT_SET;
@@ -343,4 +347,3 @@ void delayBetweenImages(config, long, std::string);
 bool getCommandLineArguments(config *, int, char *[]);
 int displayNotificationImage(char const *);
 bool validateLatitudeLongitude(config *);
-

--- a/src/include/allsky_common.h
+++ b/src/include/allsky_common.h
@@ -268,7 +268,7 @@ struct config {			// for configuration variables
 	double defaultContrast				= NOT_SET;
 	double defaultSharpness				= NOT_SET;
 	long defaultBrightness				= NOT_SET;
-	int defaultQuality;					= NOT_SET;
+	int defaultQuality					= NOT_SET;
 
 	// Current values - may vary between day and night
 	bool currentAutoExposure;

--- a/src/include/allsky_common.h
+++ b/src/include/allsky_common.h
@@ -323,7 +323,6 @@ bool getBoolean(const char *);
 double get_focus_metric(cv::Mat);
 char const *getFlip(int);
 void closeUp(int);
-void sig(int);
 void IntHandle(int);
 int stopVideoCapture(int);
 bool validateLong(long *, long, long, char const *, bool);


### PR DESCRIPTION
If the user either didn't specify an argument, or specified the default, don't pass that argument to the libcamera-still or raspistill commands.  Passing them doesn't do anything other than increase the length of the command line.