### PR TITLE
Bug fix ASI_EXPOSURE failed

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -74,6 +74,12 @@ function determineCommandToUse()
 		# Found the command - see if it works.
 		"${CMD}" --timeout 1 --nopreview > /dev/null 2>&1
 		RET=$?
+		if [[ ${RET} -eq 137 ]]; then
+			# If another libcamera-still is running the one we execute will hang for
+			# about a minute then be killed with RET=137.
+			# If that happens, assume libcamera-still is the command to use.
+			RET=0
+		fi
 	fi
 
 	if [[ ${RET} -ne 0 ]]; then

--- a/src/ASI_functions.cpp
+++ b/src/ASI_functions.cpp
@@ -1217,16 +1217,17 @@ bool setDefaults(config *cg, ASI_CAMERA_INFO ci)
 	{
 		cg->cameraMinExposure_us = cc.MinValue;
 		cg->cameraMaxExposure_us = cc.MaxValue;
+
+		ret = getControlCapForControlType(cg->cameraNumber, ASI_AUTO_MAX_EXP, &cc);
+		if (ret == ASI_SUCCESS)
+		{
+			cg->cameraMaxAutoExposure_us = cc.MaxValue * US_IN_MS;
+		} else {
+			Log(0, "ASI_AUTO_MAX_EXP failed with %s\n", getRetCode(ret));
+			ok = false;
+	}
 	} else {
 		Log(0, "ASI_EXPOSURE failed with %s\n", getRetCode(ret));
-		ok = false;
-	}
-	ret = getControlCapForControlType(cg->cameraNumber, ASI_AUTO_MAX_EXP, &cc);
-	if (ret == ASI_SUCCESS)
-	{
-		cg->cameraMaxAutoExposure_us = cc.MaxValue * US_IN_MS;
-	} else {
-		Log(0, "ASI_AUTO_MAX_EXP failed with %s\n", getRetCode(ret));
 		ok = false;
 	}
 
@@ -1565,4 +1566,3 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 
 	return(ok);
 }
-


### PR DESCRIPTION
If a user tried changing the camera type while Allsky was running it could have tried running the libcamera-still command while one was already running which caused a problem.  (I think) calling capture_ZWO when one was already running would also cause a problem.
This PR fixes the bug by stopping Allsky before changing the camera type.