### PR TITLE
install.sh: bug fix with space

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -888,8 +888,9 @@ get_locale()
 		exit 0
 	elif echo "${LOCALE}" | grep --silent "Box options" ; then
 		# Got a usage message from whiptail.
+		# Must be no space between the last double quote and ${LOCALES}.
 		#shellcheck disable=SC2086
-		MSG="Got usage message from whiptail: D='${D}', LOCALES=" ${LOCALES}
+		MSG="Got usage message from whiptail: D='${D}', LOCALES= "${LOCALES}
 		MSG="${MSG}\nFix the problem and try the installation again."
 		display_msg --log error "${MSG}"
 		exit 1


### PR DESCRIPTION
A command like:
   MSG="some message" ${LOCALES}
sets $MSG then calls ${LOCALES} which is invalid.
Need to remove the space between them.