### PR TITLE
timelapse.sh: use unique SEQUENCE_DIR names

### DIFF
--- a/scripts/timelapse.sh
+++ b/scripts/timelapse.sh
@@ -94,7 +94,7 @@ fi
 
 # To save on writes to SD card for people who have $ALLSKY_TMP as a memory filesystem,
 # put the sequence files there.
-SEQUENCE_DIR="${ALLSKY_TMP}/sequence-${DATE}"
+SEQUENCE_DIR="${ALLSKY_TMP}/sequence-${DATE}-$$"
 if [[ -d ${SEQUENCE_DIR} ]]; then
 	NSEQ=$(find "${SEQUENCE_DIR}/*" 2>/dev/null | wc -l)	# left over from last time
 else


### PR DESCRIPTION
If a mini timelapse is running at the same time as a full timelapse (which is very possible), whichever runs first will remove the $SEQUENCE_DIR directory, and because both invocations of timelapse.sh use the same directory name, the other invocation will no longer be able to find the files. This PR gives the directory a unique name by appending the timelapse.sh process ID to the name.