### PR TITLE
Support multiple cameras attached to Pi

### DIFF
--- a/allsky.sh
+++ b/allsky.sh
@@ -97,21 +97,32 @@ elif [[ ${CAMERA_TYPE} == "ZWO" ]]; then
 		sleep 3		# give it a few seconds, plus, allow the notification images to be seen
 	}
 
-	# Use two commands to better aid debugging when camera isn't found.
 	ZWOdev=$(lsusb -d '03c3:' | awk '{ bus=$2; dev=$4; gsub(/[^0-9]/,"",dev); print "/dev/bus/usb/"bus"/"dev;}')
-	ZWOIsPresent=$(lsusb -D "${ZWOdev}" 2>/dev/null | grep -c 'iProduct .*ASI[0-9]')
-	if [[ $ZWOIsPresent -eq 0 ]]; then
+	# We have to run "lsusb -D" once for each device returned by "lsusb -d", and can't
+	# use "echo x | while read" because variables set inside the "while" loop don't get exposed
+	# to the calling code, so use a temp file.
+
+	TEMP="${ALLSKY_TMP}/${CAMERA_TYPE}_cameras.txt"
+	echo "${ZWOdev}" > "${TEMP}"
+	NUM=0
+	while read -r DEV
+	do
+		if lsusb -D "${DEV}" 2>/dev/null | grep --silent 'iProduct .*ASI[0-9]' ; then
+			((NUM=NUM+1))
+		fi
+	done < "${TEMP}"
+	if [[ ${NUM} -eq 0 ]]; then
 		if [[ -n ${UHUBCTL_PATH} ]] ; then
 			reset_usb "looking for a\nZWO camera"		# reset_usb exits if too many tries
 			exit 0	# exit with 0 so the service is restarted
 		else
 			MSG="FATAL ERROR: ZWO Camera not found"
 			echo -en "${RED}*** ${MSG}" >&2
-			if [[ $ZWOdev == "" ]]; then
+			if [[ ${ZWOdev} == "" ]]; then
 				echo " and no USB entry either.${NC}" >&2
 				USB_MSG=""
 			else
-				echo " but $ZWOdev found.${NC}" >&2
+				echo " but ${ZWOdev} found.${NC}" >&2
 				USB_MSG="\n${SEE_LOG_MSG}"
 			fi
 

--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -1124,12 +1124,12 @@
 {
 "name" : "cameraType",
 "default" : "",
-"description" : "The type of camera you are using.  <span class='WebUIValue'>RPi</span> includes the HQ and compatible cameras.<br>You <b>must</b> set and change the camera here, not in config.sh.",
+"description" : "The type of camera you are using.  <span class='WebUIValue'>RPi</span> includes the HQ and compatible cameras.",
 "label" : "Camera Type",
 "type" : "select",
 "options" : [
 	{"value" : "RPi", "label" : "RPi"},
-	{"value" : "ZWO", "label" : "ZWO ASI"}
+	{"value" : "ZWO", "label" : "ZWO"}
 ],
 "display" : 1,
 "checkchanges" : 1,
@@ -1142,6 +1142,19 @@
 "label" : "Camera Model",
 "type" : "readonly",
 "display" : 1,
+"advanced" : 1
+},
+{
+"name" : "cameraNumber",
+"minimum" : 0,
+"maximum" : "none",
+"default" : 0,
+"description" : "If multiple cameras are connected to the Pi, this is the camera number (starts at 0).",
+"label" : "Camera Number",
+"type" : "number",
+"display" : "cameraNumber_display",
+"display" : 0,
+"checkchanges" : 1,
 "advanced" : 1
 },
 {

--- a/html/includes/allskySettings.php
+++ b/html/includes/allskySettings.php
@@ -8,6 +8,10 @@ function DisplayAllskyConfig(){
 
 	$cameraTypeName = "cameraType";		// json setting name
 	$cameraModelName = "cameraModel";	// json setting name
+	$cameraNumberName = "cameraNumber";	// json setting name
+	$debugLevelName = "debuglevel";		// json setting name
+	$debugArg = "";
+
 	global $lastChangedName;			// json setting name
 	global $lastChanged;
 	global $page;
@@ -39,6 +43,8 @@ function DisplayAllskyConfig(){
 			$somethingChanged = false;
 			$numErrors = 0;
 			$newCameraType = "";
+			$newCameraModel = "";
+			$newCameraNumber = "";
 			$ok = true;
 			$msg = "";
 
@@ -49,7 +55,7 @@ function DisplayAllskyConfig(){
 			}
 
 	 		foreach ($_POST as $key => $value){
-				// Anything that's sent "hidden" in a form that isnt' a settings needs to go here.
+				// Anything that's sent "hidden" in a form that isn't a settings needs to go here.
 				if (in_array($key, ["csrf_token", "save_settings", "reset_settings", "restart", "page", "_ts"]))
 					continue;
 
@@ -58,27 +64,18 @@ function DisplayAllskyConfig(){
 				// we need to escape the single quotes, but I never figured out how to do that,
 				// so convert them to HTML codes instead.
 				$isOLD = substr($key, 0, 4) === "OLD_";
-				if (! $isOLD) {
-					// Check for empty non-optional settings.
-					foreach ($options_array as $option){
-						if ($option['name'] === $key) {
-							if ($value == "" && ! $optional_array[$key]) {
-								$numErrors++;
-								$ok = false;
-							}
-						}
-					}
-
-					// Add the key/value pair to the array so we can see if it changed.
-					$settings[$key] = str_replace("'", "&#x27", $value);
-
-				} else if ($isOLD) {
+				if ($isOLD) {
 					$originalName = substr($key, 4);		// everything after "OLD_"
 					$oldValue = str_replace("'", "&#x27", $value);
 					$newValue = getVariableOrDefault($settings, $originalName, "");
 					if ($oldValue !== $newValue) {
+// if ($debugArg !== "") echo "<br>xxxxx  <b>$originalName</b> changed from '$oldValue' to '$newValue'";
 						if ($originalName === $cameraTypeName)
 							$newCameraType = $newValue;
+						elseif ($originalName === $cameraModelName)
+							$newCameraModel = $newValue;
+						elseif ($originalName === $cameraNumberName)
+							$newCameraNumber = $newValue;
 						else
 							$somethingChanged = true;	// want to know about other changes
 
@@ -96,16 +93,33 @@ function DisplayAllskyConfig(){
 						if ($checkchanges)
 							$changes .= "  '$originalName' '$label' '$newValue'";
 					}
+
+				} else {
+					// Check for empty non-optional settings.
+					foreach ($options_array as $option){
+						if ($option['name'] === $key) {
+							if ($value == "" && ! $optional_array[$key]) {
+								$numErrors++;
+								$ok = false;
+							}
+						}
+					}
+
+					// Add the key/value pair to the array so we can see if it changed.
+					$settings[$key] = str_replace("'", "&#x27", $value);
+
+					if ($key === $debugLevelName && $value >= 4) {
+						$debugArg = "--debug";
+					}
 				}
 			}
 
-// TODO: should we update the settings file first, or run makeChanges.sh ?
-// It's probably more likely makeChange.sh would fail than updating the settings file,
-// so it should probably go first.
+// TODO: makeChanges.sh should probably come first because if it fails, we don't want
+// to update the settings file.
 			if ($ok) {
 				if ($somethingChanged || $lastChanged === null) {
-					if ($newCameraType !== "") {
-						$msg = "If you change <b>Camera Type</b> you cannot change anything else.  No changes made.";
+					if ($newCameraType !== "" || $newCameraModel !== "" || $newCameraNumber != "") {
+						$msg = "If you change <b>Camera Type</b>, <b>Camera Model</b>, or <b>Camera Number</b>  you cannot change anything else.  No changes made.";
 						$ok = false;
 					} else {
 						// Keep track of the last time the file changed.
@@ -120,10 +134,21 @@ function DisplayAllskyConfig(){
 						else
 							$ok = false;
 					}
-				} else if ($newCameraType !== "") {
-					$msg = "<b>Camera Type</b> changed to <b>$newCameraType</b>";
 				} else {
-					$msg = "No settings changed (file not updated)";
+					if ($newCameraType !== "") {
+						$msg .= "<b>Camera Type</b> changed to <b>$newCameraType</b>";
+					}
+					if ($newCameraModel !== "") {
+						if ($msg !== "") $msg = "<br>$msg";
+						$msg .= "<b>Camera Model</b> changed to <b>$newCameraModel</b>";
+					}
+					if ($newCameraNumber !== "") {
+						if ($msg !== "") $msg = "<br>$msg";
+						$msg .= "<b>Camera Number</b> changed to <b>$newCameraNumber</b>";
+					}
+
+					if ($msg === "")
+						$msg = "No settings changed (file not updated)";
 				}
 			}
 
@@ -140,19 +165,21 @@ function DisplayAllskyConfig(){
 					else
 						$restarting = "";
 					$CMD = "sudo --user=" . ALLSKY_OWNER;
-					$CMD .= " " . ALLSKY_SCRIPTS . "/makeChanges.sh $restarting $changes";
+					$CMD .= " " . ALLSKY_SCRIPTS . "/makeChanges.sh $debugArg $restarting $changes";
 					# Let makeChanges.sh display any output
 					echo '<script>console.log("Running: ' . $CMD . '");</script>';
-					runCommand($CMD, "", "success");
+					$ok = runCommand($CMD, "", "success");
 				}
 
-				if ($doingRestart) {
-					$msg .= " and Allsky restarted.";
-					// runCommand displays $msg.
-					runCommand("sudo /bin/systemctl reload-or-restart allsky.service", $msg, "success");
-				} else {
-					$msg .= " but Allsky NOT restarted.";
-					$status->addMessage($msg, 'info');
+				if ($ok) {
+					if ($doingRestart) {
+						$msg .= " and Allsky restarted.";
+						// runCommand displays $msg.
+						runCommand("sudo /bin/systemctl reload-or-restart allsky.service", $msg, "success");
+					} else {
+						$msg .= " but Allsky NOT restarted.";
+						$status->addMessage($msg, 'info');
+					}
 				}
 
 			} else {	// not $ok

--- a/html/includes/createAllskyOptions.php
+++ b/html/includes/createAllskyOptions.php
@@ -2,8 +2,6 @@
 <?php
 
 // Create a camera type/model-specific "options" file for the new camera.
-// Because php scripts don't return exit codes, we'll output "XX_WORKED_XX" if it worked
-// so the invoker knows.
 
 include_once('functions.php');
 
@@ -242,25 +240,25 @@ foreach ($options as $opt => $val) {
 
 if ($help || $cc_file === "" || $options_file === "") {
 	echo "\nUsage: " . basename($argv[0]) . " [--debug] [--debug2] [--help] [--settings_file file] --cc_file file --options_file file\n";
-	exit;
+	exit(1);
 }
 
 if (! file_exists($cc_file)) {
 	echo "ERROR: Camera capabilities file $cc_file does not exist!\n";
 	echo "Run 'install.sh --update' to create it.\n";
-	exit;
+	exit(2);
 }
 $repo_file = ALLSKY_REPO . "/" . basename($options_file) . ".repo";
 if (! file_exists($repo_file)) {
 	echo "ERROR: Template options file $repo_file does not exist!\n";
-	exit;
+	exit(3);
 }
 
 // Read $cc_file
 $errorMsg = "ERROR: Unable to process cc file '$cc_file'.";
 $cc_array = get_decoded_json_file($cc_file, true, $errorMsg);
 if ($cc_array === null) {
-	exit;
+	exit(4);
 }
 $cc_controls = $cc_array["controls"];
 $cameraType = $cc_array["cameraType"];
@@ -271,7 +269,7 @@ if ($debug > 0) echo "cameraType=$cameraType, cameraModel=$cameraModel\n";
 $errorMsg = "ERROR: Unable to process template options file '$repo_file'.";
 $repo_array = get_decoded_json_file($repo_file, true, $errorMsg);
 if ($repo_array === null) {
-	exit;
+	exit(5);
 }
 
 // All entries except the last "XX_END_XX" name have a "type". 
@@ -365,7 +363,7 @@ $options_str .= "]\n\n";
 $results = updateFile($options_file, $options_str, "options", true);
 if ($results != "") {
 	echo "ERROR: Unable to create $options_file.\n";
-	exit;
+	exit(6);
 }
 
 // Optionally create a basic "settings" file with the default for this camera type/model.
@@ -379,7 +377,7 @@ if ($settings_file !== "") {
 		if ($debug > 0) echo "Removing $settings_file.\n";
 		if (! unlink($settings_file)) {
 			echo "ERROR: Unable to delete $settings_file.\n";
-			exit;
+			exit(7);
 		}
 	}
 
@@ -417,7 +415,7 @@ if ($settings_file !== "") {
 		$results = updateFile($fullName, $contents, $cameraSpecificSettingsFile, true);
 		if ($results != "") {
 			echo "ERROR: Unable to create $fullName.\n";
-			exit;
+			exit(8);
 		}
 
 	} else if ($debug > 0) {
@@ -430,10 +428,9 @@ if ($settings_file !== "") {
 	if ($debug > 0) echo "Linking $settings_file to $fullName.\n";
 	if (! link($fullName, $settings_file)) {
 		echo "ERROR: Unable to link $settings_file to $fullName.\n";
-		exit;
+		exit(9);
 	}
 }
 
-echo "XX_WORKED_XX\n";
-
+exit(0);
 ?>

--- a/html/includes/functions.php
+++ b/html/includes/functions.php
@@ -556,7 +556,7 @@ function runCommand($cmd, $message, $messageColor)
 	} elseif ($return_val > 0) {
 		// Display a failure message, plus the caller's message, if any.
 		$msg = "'$cmd' failed";
-		if ($result != null) $msg .= ": " . implode("<br>", $result);
+		if ($result != null) $msg .= ":<br>" . implode("<br>", $result);
 		$status->addMessage($msg, "danger", true);
 		return false;
 	}


### PR DESCRIPTION
It's possible to have multiple ZWO cameras attached to the Pi at once (not sure about RPi).
This PR allows the user to specify which camera to use via a new "Camera Number" setting in the WebUI.

This works well, but switching cameras in the WebUI needs more testing, so the "Camera Number" field is hidden in this release.