### PR TITLE
Temp code to move modules that have changed location  during development

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1596,8 +1596,23 @@ install_overlay()
 
 	MODULE_LOCATION="/opt/allsky"
 	sudo mkdir -p "${MODULE_LOCATION}/modules"
+
+	# TODO: Remove in next release. Temporary fix to move modules and deal with pistatus and gps that have moved to core allsky
+	if [[ -d /etc/allsky/modules ]]; then
+		sudo cp -a /etc/allsky/modules "${MODULE_LOCATION}"
+		sudo rm -rf /etc/allsky
+	fi
+
+	if [[ -f "/opt/allsky/modules/allsky_pistatus.py" ]]; then
+    	sudo rm "/opt/allsky/modules/allsky_pistatus.py"
+	fi
+	if [[ -f "/opt/allsky/modules/allsky_script.py" ]]; then
+    	sudo rm "/opt/allsky/modules/allsky_script.py"
+	fi	
+	#TODO: End
+
 	sudo chown -R "${ALLSKY_OWNER}:${WEBSERVER_GROUP}" "${MODULE_LOCATION}"
-	sudo chmod -R 774 "${MODULE_LOCATION}"
+	sudo chmod -R 774 "${MODULE_LOCATION}"			
 }
 
 


### PR DESCRIPTION
- Checks if modules are in /etc/allsky and if so move them to the new location /opt/allsky
- If the pistatus or pigps modules exist in /opt/allsky/modules then delete them as they are now part of core allsky