### PR TITLE
options.json.repo: hide locale

### DIFF
--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -682,7 +682,7 @@
 "description" : "Your locale, used to determine what the thousands and decimal separators are.<br>Type 'locale' at a command prompt to see your choices.",
 "label" : "Locale",
 "type" : "text",
-"display" : 1,
+"display" : 0,
 "advanced" : 0
 },
 {


### PR DESCRIPTION
It's now set during installation if needed, and passed to capture programs via allsky.sh. If this works, the whole "locale" block should be removed and the "locale" setting should be removed.