### PR TITLE
endOfNight.sh fix with directory name

### DIFF
--- a/scripts/endOfNight.sh
+++ b/scripts/endOfNight.sh
@@ -88,8 +88,8 @@ cmd="${ALLSKY_SCRIPTS}/endOfNight_additionalSteps.sh"
 # Automatically delete old images and videos
 if [[ -n ${DAYS_TO_KEEP} ]]; then
 	del=$(date --date="${DAYS_TO_KEEP} days ago" +%Y%m%d)
-	# "2*" for years >= 2000
-	find "${ALLSKY_IMAGES}/" -type d -name "2*" | while read -r i
+	# "20*" for years >= 2000
+	find "${ALLSKY_IMAGES}/" -type d -name "20*" | while read -r i
 	do
 		((del > $(basename "${i}"))) && echo "${ME}: Deleting old directory ${i}" && rm -rf "${i}"
 	done

--- a/scripts/endOfNight.sh
+++ b/scripts/endOfNight.sh
@@ -88,10 +88,13 @@ cmd="${ALLSKY_SCRIPTS}/endOfNight_additionalSteps.sh"
 # Automatically delete old images and videos
 if [[ -n ${DAYS_TO_KEEP} ]]; then
 	del=$(date --date="${DAYS_TO_KEEP} days ago" +%Y%m%d)
-	# "20*" for years >= 2000
-	find "${ALLSKY_IMAGES}/" -type d -name "20*" | while read -r i
+	# "20*" for years >= 2000.   Format:  YYYYMMDD
+	#													YY  Y    Y   M    M   D      D
+	find "${ALLSKY_IMAGES}/" -maxdepth 1 -type d -name "20[2-9][0-9][01][0-9][0123][0-9]" | \
+		while read -r i
+
 	do
-		((del > $(basename "${i}"))) && echo "${ME}: Deleting old directory ${i}" && rm -rf "${i}"
+		(( del > $(basename "${i}") )) && echo "${ME}: Deleting old directory ${i}" && rm -rf "${i}"
 	done
 fi
 


### PR DESCRIPTION
Bug fix: if the allsky/images directory had directories with names that started with "20" but weren't all numeric, the (( )) check could fail.
This PR only checks directories that have format YYYYMMDD.