### PR TITLE
install.sh: display single row in --menu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -992,7 +992,7 @@ get_locale()
 	local IL=()
 	for i in ${INSTALLED_LOCALES}
 	do
-		IL+=($i "")
+		IL+=("$i" "")
 	done
 
 	#shellcheck disable=SC2086
@@ -1006,9 +1006,9 @@ get_locale()
 		exit 0
 	elif echo "${LOCALE}" | grep --silent "Box options" ; then
 		# Got a usage message from whiptail.
-		# Must be no space between the last double quote and ${LOCALES}.
+		# Must be no space between the last double quote and ${INSTALLED_LOCALES}.
 		#shellcheck disable=SC2086
-		MSG="Got usage message from whiptail: D='${D}', LOCALES="${LOCALES}
+		MSG="Got usage message from whiptail: D='${D}', INSTALLED_LOCALES="${INSTALLED_LOCALES}
 		MSG="${MSG}\nFix the problem and try the installation again."
 		display_msg --log error "${MSG}"
 		exit 1

--- a/install.sh
+++ b/install.sh
@@ -987,13 +987,16 @@ get_locale()
 	MSG="${MSG}\nyou will need to restart the installation."
 	[[ -n ${MSG2} ]] && MSG="${MSG}\n\n${MSG2}"
 
-# TODO: replace "." in printf() with something (I don't know what) so whiptail gets a null or
-# space for the 2nd arguments in the pair.
-	local LOCALES="$( echo "${INSTALLED_LOCALES}" | awk '{ printf("%s %s ", $1, ".") }' )"
-	[[ ${DEBUG} -gt 1 ]] && echo "LOCALES=${LOCALES}"
+	# This puts in IL the necessary strings to have whiptail display what looks like
+	# a single column of selections.
+	local IL=()
+	for i in ${INSTALLED_LOCALES}
+	do
+		IL+=($i "")
+	done
 
 	#shellcheck disable=SC2086
-	LOCALE=$(whiptail --title "${TITLE}" ${D} --menu "${MSG}" 25 "${WT_WIDTH}" 4 ${LOCALES} \
+	LOCALE=$(whiptail --title "${TITLE}" ${D} --menu "${MSG}" 25 "${WT_WIDTH}" 4 "${IL[@]}" \
 		3>&1 1>&2 2>&3)
 	if [[ -z ${LOCALE} ]]; then
 		MSG="You need to set the locale before the installation can run."


### PR DESCRIPTION
"whiptail --menu" requires groups of 2 arguments - a tag and item/description. In our case, the tag and description are the same string so this PR basically presents whiptail with an array of ' tag "" ' strings.