### PR TITLE
Overlay.json updates

### DIFF
--- a/config_repo/overlay/config/overlay-RPi.json
+++ b/config_repo/overlay/config/overlay-RPi.json
@@ -1,54 +1,51 @@
 {
     "fields": [
         {
-            "label": "${DATE}",
-            "x": 172,
-            "y": 60,
-            "id": "oe-field-4",
-            "format": "%d-%m-%Y",
+            "label": "${DATE} ${TIME}",
+            "x": 330,
+            "y": 50,
+            "id": "oe-field-0",
+            "format": "%d-%m-%Y,%H:%M:%S",
             "strokewidth": 0,
-            "sample": "DATE",
-            "tlx": 19,
-            "tly": 20,
+            "sample": "DATE,TIME",
+            "tlx": 10,
+            "tly": 10,
             "font": "Arial",
             "fontsize": 80,
-            "fill": "#ff0000"
-        },
-        {
-            "label": "${TIME}",
-            "x": 624,
-            "y": 60,
-            "id": "oe-field-5",
-            "format": "%H:%M:%S",
-            "strokewidth": 0,
-            "sample": "TIME",
-            "tlx": 479,
-            "tly": 20,
-            "fontsize": 80,
-            "font": "Arial",
             "fill": "#ff0000"
         },
         {
             "label": "Exposure: ${sEXPOSURE}",
-            "x": 430,
-            "y": 154,
-            "id": "oe-field-6",
+            "x": 421,
+            "y": 124,
+            "id": "oe-field-1",
             "font": "Arial",
             "fontsize": 68,
             "strokewidth": 0,
-            "tlx": 19,
-            "tly": 120
+            "tlx": 10,
+            "tly": 90
         },
         {
             "label": "Gain: ${GAIN}",
-            "x": 235,
-            "y": 234,
-            "id": "oe-field-7",
+            "x": 226,
+            "y": 194,
+            "id": "oe-field-2",
             "font": "Arial",
             "fontsize": 68,
             "strokewidth": 0,
-            "tlx": 19,
-            "tly": 200
+            "tlx": 10,
+            "tly": 160
+        },
+        {
+            "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
+            "x": 419,
+            "y": 3002,
+            "id": "oe-field-3",
+            "fontsize": 44,
+            "strokewidth": 0,
+            "sample": "RPi HQ",
+            "tlx": 10,
+            "tly": 2980
         }
     ],
     "images": [],

--- a/config_repo/overlay/config/overlay-ZWO.json
+++ b/config_repo/overlay/config/overlay-ZWO.json
@@ -34,11 +34,23 @@
             "tly": 70
         },
         {
-            "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
-            "x": 158,
-            "y": 1078,
+            "label": "Sensor: ${TEMPERATURE_C} C",
+            "x": 215,
+            "y": 114,
             "id": "oe-field-3",
-            "fontsize": 16,
+            "format": "{:.1f}",
+            "fontsize": 28,
+            "strokewidth": 0,
+            "tlx": 9,
+            "tly": 100,
+            "sample": "20.1"
+        },
+        {
+            "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
+            "x": 195,
+            "y": 1080,
+            "id": "oe-field-4",
+            "fontsize": 20,
             "strokewidth": 0,
             "sample": "ZWO ASI174MC",
             "tlx": 9,
@@ -70,4 +82,3 @@
         }
     }
 }
-

--- a/config_repo/overlay/config/overlay-ZWO.json
+++ b/config_repo/overlay/config/overlay-ZWO.json
@@ -1,63 +1,48 @@
 {
     "fields": [
         {
-            "label": "${DATE}",
-            "x": 73,
-            "y": 14,
+            "label": "${DATE}  ${TIME}",
+            "x": 121,
+            "y": 24,
             "id": "oe-field-0",
-            "format": "%d-%m-%Y",
+            "format": "%d-%m-%Y,%H:%M:%S",
             "strokewidth": 0,
-            "sample": "DATE",
-            "tlx": 19,
-            "tly": 0,
+            "sample": "DATE,TIME",
+            "tlx": 9,
+            "tly": 10,
             "fontsize": 28,
-            "fill": "#ff0000",
-            "opacity": "1"
-        },
-        {
-            "label": "${TIME}",
-            "x": 230,
-            "y": 14,
-            "id": "oe-field-1",
-            "format": "%H:%M:%S",
-            "strokewidth": 0,
-            "sample": "TIME",
-            "tlx": 179,
-            "tly": 0,
-            "fontsize": 28,
-            "fill": "#ff0000",
-            "opacity": "1"
+            "fill": "#ff0000"
         },
         {
             "label": "Exposure: ${sEXPOSURE}",
-            "x": 188,
+            "x": 178,
             "y": 54,
-            "id": "oe-field-2",
+            "id": "oe-field-1",
             "fontsize": 28,
             "strokewidth": 0,
-            "tlx": 19,
+            "tlx": 9,
             "tly": 40
         },
         {
             "label": "Gain: ${GAIN}",
-            "x": 108,
-            "y": 94,
-            "id": "oe-field-3",
+            "x": 98,
+            "y": 84,
+            "id": "oe-field-2",
             "fontsize": 28,
             "strokewidth": 0,
-            "tlx": 19,
-            "tly": 80
+            "tlx": 9,
+            "tly": 70
         },
         {
-            "label": "Sensor: ${TEMPERATURE_C}C",
-            "x": 222,
-            "y": 134,
-            "id": "oe-field-4",
-            "fontsize": 28,
+            "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
+            "x": 158,
+            "y": 1078,
+            "id": "oe-field-3",
+            "fontsize": 16,
             "strokewidth": 0,
-            "tlx": 19,
-            "tly": 120,
-            "sample": ""
+            "sample": "ZWO ASI174MC",
+            "tlx": 9,
+            "tly": 1070
         }
     ],
     "images": [],
@@ -85,3 +70,4 @@
         }
     }
 }
+

--- a/config_repo/overlay/config/overlay.json
+++ b/config_repo/overlay/config/overlay.json
@@ -1,65 +1,40 @@
 {
     "fields": [
         {
-            "label": "${DATE}",
-            "x": 124,
-            "y": 47,
-            "id": "oe-field-4",
-            "format": "%d-%m-%Y",
+            "label": "${DATE} ${TIME}",
+            "x": 118,
+            "y": 24,
+            "id": "oe-field-0",
+            "format": "%d-%m-%Y,%H:%M:%S",
             "strokewidth": 0,
-            "sample": "DATE",
-            "tlx": 19,
-            "tly": 20,
+            "sample": "DATE,TIME",
+            "tlx": 10,
+            "tly": 10,
             "font": "Arial",
             "fontsize": 80,
-            "fill": "#ff0000"
-        },
-        {
-            "label": "${TIME}",
-            "x": 579,
-            "y": 47,
-            "id": "oe-field-5",
-            "format": "%H:%M:%S",
-            "strokewidth": 0,
-            "sample": "TIME",
-            "tlx": 479,
-            "tly": 20,
-            "fontsize": 80,
-            "font": "Arial",
             "fill": "#ff0000"
         },
         {
             "label": "Exposure: ${sEXPOSURE}",
-            "x": 348,
-            "y": 147,
-            "id": "oe-field-6",
+            "x": 179,
+            "y": 64,
+            "id": "oe-field-1",
             "font": "Arial",
             "fontsize": 68,
             "strokewidth": 0,
-            "tlx": 19,
-            "tly": 120
+            "tlx": 10,
+            "tly": 50
         },
         {
             "label": "Gain: ${GAIN}",
-            "x": 194,
-            "y": 227,
-            "id": "oe-field-7",
+            "x": 98,
+            "y": 99,
+            "id": "oe-field-2",
             "font": "Arial",
             "fontsize": 68,
             "strokewidth": 0,
-            "tlx": 19,
-            "tly": 200
-        },
-        {
-            "label": "Sensor: ${TEMPERATURE_C}",
-            "x": 359,
-            "y": 307,
-            "id": "oe-field-8",
-            "font": "Arial",
-            "fontsize": 68,
-            "strokewidth": 0,
-            "tlx": 19,
-            "tly": 280
+            "tlx": 10,
+            "tly": 90
         }
     ],
     "images": [],

--- a/config_repo/overlay/config/overlay.json
+++ b/config_repo/overlay/config/overlay.json
@@ -1,40 +1,48 @@
 {
     "fields": [
         {
-            "label": "${DATE} ${TIME}",
-            "x": 118,
+            "label": "${DATE}  ${TIME}",
+            "x": 121,
             "y": 24,
             "id": "oe-field-0",
             "format": "%d-%m-%Y,%H:%M:%S",
             "strokewidth": 0,
             "sample": "DATE,TIME",
-            "tlx": 10,
+            "tlx": 9,
             "tly": 10,
-            "font": "Arial",
-            "fontsize": 80,
+            "fontsize": 28,
             "fill": "#ff0000"
         },
         {
             "label": "Exposure: ${sEXPOSURE}",
-            "x": 179,
-            "y": 64,
+            "x": 178,
+            "y": 54,
             "id": "oe-field-1",
-            "font": "Arial",
-            "fontsize": 68,
+            "fontsize": 28,
             "strokewidth": 0,
-            "tlx": 10,
-            "tly": 50
+            "tlx": 9,
+            "tly": 40
         },
         {
             "label": "Gain: ${GAIN}",
             "x": 98,
-            "y": 99,
+            "y": 84,
             "id": "oe-field-2",
-            "font": "Arial",
-            "fontsize": 68,
+            "fontsize": 28,
             "strokewidth": 0,
-            "tlx": 10,
-            "tly": 90
+            "tlx": 9,
+            "tly": 70
+        },
+        {
+            "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
+            "x": 158,
+            "y": 1078,
+            "id": "oe-field-3",
+            "fontsize": 16,
+            "strokewidth": 0,
+            "sample": "ZWO ASI174MC",
+            "tlx": 9,
+            "tly": 1070
         }
     ],
     "images": [],


### PR DESCRIPTION
In the repo `overlay*.json` files:
* Merge the DATE and TIME fields since users typically want both of them, and it's easier to deal with as one field.
* Add CAMERA_TYPE and CAMERA_MODEL to the bottom left of the image.
* Remove TEMPERATURE_C from RPi version.
* Set the fall-back "overlay.json" file to be the ZWO version without TEMPERATURE_C.