### PR TITLE
Fix to remove large black block under the overlay editor 

### DIFF
--- a/html/js/overlay/oe-uimanager.js
+++ b/html/js/overlay/oe-uimanager.js
@@ -50,9 +50,7 @@ class OEUIMANAGER {
             height: height,
             draggable: true
         });
-
-        this.setZoom('oe-zoom-fit');
-
+                
         this.#backgroundLayer = new Konva.Layer();
         this.#backgroundLayer.add(this.#backgroundImage);
         this.#oeEditorStage.add(this.#backgroundLayer);
@@ -66,6 +64,8 @@ class OEUIMANAGER {
             resizeEnabled: false
         });
         this.#overlayLayer.add(this.#transformer);
+
+        this.setZoom('oe-zoom-fit');
 
         this.#snapRectangle = new Konva.Rect({
             x: 0,
@@ -1196,6 +1196,13 @@ class OEUIMANAGER {
         }
 
         this.#oeEditorStage.scale({ x: this.#stageScale, y: this.#stageScale });
+
+        let height = (this.#backgroundImage.height() * this.#stageScale);
+
+        // Not very nice 'fix' to prevent the scaled stage from having a huge black block underneath it
+        $('#overlay_container').height(height);
+        
+
     }
 
     loadBackgroundImage() {


### PR DESCRIPTION
This is caused by the html canvas having the same height as the raw image but drawing on the stage is done using scaling on x and y.

The fix is not ideal and this will need looking at again