### PR TITLE
check_allsky.sh: handle tilda

### DIFF
--- a/scripts/check_allsky.sh
+++ b/scripts/check_allsky.sh
@@ -187,6 +187,9 @@ function check_PROTOCOL()
 # Check that when a variable holds a location, the location exists.
 function check_exists() {
 	local VALUE="${!1}"
+	if [[ ${VALUE:0:1} == "~" ]]; then
+		VALUE="${HOME}${VALUE:1}"
+	fi
 	if [[ -n ${VALUE} && ! -e ${VALUE} ]]; then
 		heading "Warnings"
 		echo "${1} is set to '${VALUE}' but it does not exist."


### PR DESCRIPTION
For whatever reason, a tilda at the start of a file/directory name wasn't working so the item wasn't found. Replace tilda with $HOME so it works.