### PR TITLE
Use apt-get rather than apt

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -89,7 +89,7 @@ deps:
 else
 deps:
 	@echo `date +%F\ %R:%S` Installing build dependencies...
-	@apt update && apt -y install libopencv-dev libusb-dev libusb-1.0-0-dev ffmpeg gawk lftp jq imagemagick bc
+	@apt-get update && apt-get -y install libopencv-dev libusb-dev libusb-1.0-0-dev ffmpeg gawk lftp jq imagemagick bc
 endif
 
 .PHONY : deps


### PR DESCRIPTION
This will remove the "apt does not have a stable CLI interface. Use with caution in scripts." warning