### PR TITLE
install.sh: bug fix: write error to stdout

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1271,7 +1271,7 @@ prompt_for_lat_long()
 			# Let the user not enter anything.  A message is printed below.
 			break
 		else
-			if VALUE="$(convertLatLong "${VALUE}" "${TYPE}")" ; then
+			if VALUE="$( convertLatLong "${VALUE}" "${TYPE}" 2>&1 )" ; then
 				jq ".${TYPE}=\"${VALUE}\" "   "${SETTINGS_FILE}" > /tmp/x && mv /tmp/x "${SETTINGS_FILE}"
 				display_msg --log progress "${HUMAN_TYPE} set to ${VALUE}."
 				echo "${VALUE}"


### PR DESCRIPTION
Error message needs to go to stdout so $VALUE can be set correctly.