### PR TITLE
options.json.repo: display locale

### DIFF
--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -682,7 +682,7 @@
 "description" : "Your locale, used to determine what the thousands and decimal separators are.<br>Type 'locale' at a command prompt to see your choices.",
 "label" : "Locale",
 "type" : "text",
-"display" : 0,
+"display" : 1,
 "advanced" : 0
 },
 {


### PR DESCRIPTION
If a user set their settings back to defaults then there was no way to set the locale since it wasn't displayed.