### PR TITLE
Add ${DESTINATION_NAME} to s3 upload target

### DIFF
--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -177,11 +177,10 @@ trap "" SIGTERM
 trap "" SIGHUP
 
 if [[ ${PROTOCOL} == "s3" ]] ; then
-	# xxxxxx How do you tell it the DESTINATION_NAME name ?
 	if [[ ${SILENT} == "false" && ${ALLSKY_DEBUG_LEVEL} -ge 3 ]]; then
 		echo "${ME}: Uploading ${FILE_TO_UPLOAD} to aws ${S3_BUCKET}/${REMOTE_DIR}"
 	fi
-	OUTPUT="$("${AWS_CLI_DIR}/aws" s3 cp "${FILE_TO_UPLOAD}" "s3://${S3_BUCKET}${REMOTE_DIR}" --acl "${S3_ACL}" 2>&1)"
+	OUTPUT="$("${AWS_CLI_DIR}/aws" s3 cp "${FILE_TO_UPLOAD}" "s3://${S3_BUCKET}${REMOTE_DIR}${DESTINATION_NAME}" --acl "${S3_ACL}" 2>&1)"
 	RET=$?
 
 


### PR DESCRIPTION
Fixes image uploads to S3 when using `IMG_UPLOAD_ORIGINAL_NAME="false"` in config.sh. (Images are uploaded with date/time in the name when they shouldn't).

See https://github.com/thomasjacquin/allsky/discussions/1193#discussioncomment-5959444