### PR TITLE
removeBadImages.sh: bug fix with decimal HIGH

### DIFF
--- a/scripts/removeBadImages.sh
+++ b/scripts/removeBadImages.sh
@@ -198,7 +198,7 @@ for f in ${IMAGE_FILES} ; do
 			echo "${r} ${BAD}" >> "${OUTPUT}"
 		fi
 		[[ ${DEBUG} == "false" ]] && rm -f "${f}" "thumbnails/${f}"
-		$((num_bad++))
+		((num_bad++))
 	fi
 done
 


### PR DESCRIPTION
* Convert all comparisons of LOW and HIGH to use "bc".  Previously we compared "HIGH -gt 100" but if HIGH was 100.0 it failed.
* Remove a couple unneeded comments.