### PR TITLE
Allsky settings optionally don't add to error message

### DIFF
--- a/html/includes/allskySettings.php
+++ b/html/includes/allskySettings.php
@@ -186,7 +186,8 @@ function DisplayAllskyConfig(){
 					$CMD .= " " . ALLSKY_SCRIPTS . "/makeChanges.sh $debugArg $moreArgs $changes";
 					# Let makeChanges.sh display any output
 					echo '<script>console.log("Running: ' . $CMD . '");</script>';
-					$ok = runCommand($CMD, "", "success");
+					// false = don't add anything to the message
+					$ok = runCommand($CMD, "", "success", false);
 				}
 
 				if ($ok) {
@@ -567,3 +568,4 @@ if ($formReadonly != "readonly") { ?>
 <?php
 }
 ?>
+

--- a/html/includes/functions.php
+++ b/html/includes/functions.php
@@ -555,8 +555,9 @@ function ListFileType($dir, $imageFileName, $formalImageTypeName, $type) {	// if
         echo "</div>";
 }
 
-/* Run a command and display the appropriate status message */
-function runCommand($cmd, $message, $messageColor)
+// Run a command and display the appropriate status message.
+// If $addMsg is false, then don't add our own message.
+function runCommand($cmd, $message, $messageColor, $addMsg=true)
 {
 	global $status;
 
@@ -569,8 +570,13 @@ function runCommand($cmd, $message, $messageColor)
 		return false;
 	} elseif ($return_val > 0) {
 		// Display a failure message, plus the caller's message, if any.
-		$msg = "'$cmd' failed";
-		if ($result != null) $msg .= ":<br>" . implode("<br>", $result);
+		if ($addMsg) {
+			$msg = "'$cmd' failed";
+			if ($result != null) $msg .= ":<br>" . implode("<br>", $result);
+		} else {
+			if ($result != null) $msg = implode("<br>", $result);
+			else $msg = "";
+		}
 		$status->addMessage($msg, "danger", true);
 		return false;
 	}


### PR DESCRIPTION
When error messages include the command executed as well as it's error output, that looks ugly from a user's perspective.  They don't know what the command is.  This is especially true with makeChanges.sh, so don't show the command executed.