### PR TITLE
Fix js errors thrown on pages other than settings cased by https://github.com/thomasjacquin/allsky/pull/2666

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -493,26 +493,36 @@ if (file_exists($f)) {
 	addTimestamp("system");
 
 
+
+<?php
+// Only include the sticky buttons on the settings page
+if ($page == "configuration") {
+?>
 	// The remaining code is to keep the "Save changes" button at the top of the "settings" page.
 	// Get the button:
 	let mybutton = document.getElementById("backToTopBtn");
 
-	// When the user scrolls down 20px from the top of the document, show the button
-	window.onscroll = function() {scrollFunction()};
+	if (mybutton !== null) {
+		// When the user scrolls down 20px from the top of the document, show the button
+		window.onscroll = function() {scrollFunction()};
 
-	function scrollFunction() {
-		if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
-			mybutton.style.display = "block";
-		} else {
-			mybutton.style.display = "none";
+		function scrollFunction() {
+			if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+				mybutton.style.display = "block";
+			} else {
+				mybutton.style.display = "none";
+			}
+		}
+
+		// When the user clicks on the button, scroll to the top of the document
+		function topFunction() {
+			document.body.scrollTop = 0; // For Safari
+			document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
 		}
 	}
-
-	// When the user clicks on the button, scroll to the top of the document
-	function topFunction() {
-		document.body.scrollTop = 0; // For Safari
-		document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+<?php 
 	}
+?>
 </script>
 </body>
 </html>


### PR DESCRIPTION
The recent merge for keeping the save buttons at the top of the page is not checking that the button exists. On pages that dont have the buttons Javascript errors are being thrown as the page scrolls.

Changed the code to only add the stick logic on the settings page