### PR TITLE
Use 'external' attribute in documentation

### DIFF
--- a/html/documentation/explanations/SystemPageAdditions.html
+++ b/html/documentation/explanations/SystemPageAdditions.html
@@ -395,7 +395,7 @@ so this step doesn't apply to them.
 You like green so will make the dew heater toggle button green by specifying its <b>button color</b> as <code>green</code>.
 <p>
 You want an icon on the button since the other buttons have icons,
-so you go to <a href="https://fontawesome.com/icons/" target="_blank">Font Awesome <i class="fa fa-external-link-alt fa-fw"></i></a>
+so you go to <a external="true" href="https://fontawesome.com/icons/" target="_blank">Font Awesome</a>
 to look for an icon (Allsky uses Font Awesome version 6).
 You pick the "random" icon so set the button's <b>FA icon</b> field to <code>random</code>.
 </p>

--- a/html/documentation/miscellaneous/AllskyMap.html
+++ b/html/documentation/miscellaneous/AllskyMap.html
@@ -29,7 +29,7 @@
 <p>
 Starting with version 0.8.3.3 of Allsky,
 you can automatically have your allsky camera(s) added to the global
-<a href="https://www.thomasjacquin.com/allsky-map/" target="_blank">Allsky Map <i class="fa fa-external-link-alt fa-fw"></i></a>.
+<a external="true" href="https://www.thomasjacquin.com/allsky-map/" target="_blank">Allsky Map</a>.
 This map shows the location of all known allsky cameras as well as basic information about them.
 Click on the image below to go to the Allsky Map.
 </p>
@@ -60,7 +60,7 @@ And if the owner set their website URL you can click on the image to go to their
 
 <p>
 See the <b>"Allsky Settings" Page</b> section of the
-<a allsky="true" href="/documentation/settings/allsky.html" target="_blank">Allsky Settings <i class="fa fa-external-link-alt fa-fw"></i></a>
+<a allsky="true" external="true" href="/documentation/settings/allsky.html" target="_blank">Allsky Settings</a>
 page for a description of each map-related setting in the WebUI.
 </p>
 

--- a/html/documentation/settings/allsky.html
+++ b/html/documentation/settings/allsky.html
@@ -809,7 +809,7 @@ Settings in the <span class="dropdown">configuration.json</span> files are descr
 </p>
 <p>
 Information on the color scheme used by the Editor in the screenshot above is
-<a allsky="true" href="EditorColors.html" target="_blank" title="Opens in new tab">here <i class="fa fa-external-link-alt fa-fw"></i></a>.
+<a allsky="true" external="true" href="EditorColors.html" target="_blank" title="Opens in new tab">here </a>.
 </p>
 
 <h3>config.sh settings</h3>

--- a/html/documentation/settings/allskyWebsite.html
+++ b/html/documentation/settings/allskyWebsite.html
@@ -65,7 +65,7 @@ To configure the Website:
 <p>
 The sections below list all the settings, their default values, and a description.
 Information on the color scheme used by the Editor is
-<a allsky="true" href="EditorColors.html" target="_blank" title="Opens in new tab">here <i class="fa fa-external-link-alt fa-fw"></i></a>.
+<a allsky="true" external="true" href="EditorColors.html" target="_blank" title="Opens in new tab">here</a>.
 </p>
 
 


### PR DESCRIPTION
Use    `external="true"` instead of hard-coding the "external" web page symbol.  This makes it easier to globally change if needed.