### PR TITLE
Fix install.sh bug when updating settings file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1081,7 +1081,8 @@ update_locale()
 {
 	local L="${1}"		# locale
 	local S="${2}"		# settings file
-	jq ".locale = \"${L}\"" "${S}" > /tmp/x && mv /tmp/x "${S}"
+	# Have to use "cp" instead of "mv" to keep the hard link.
+	jq ".locale = \"${L}\"" "${S}" > /tmp/x && cp /tmp/x "${S}" && rm /tmp/x
 }
 ####
 # Set the locale


### PR DESCRIPTION
Using "mv" to replace a file removes any hard links it has, so use "cp" instead.