### PR TITLE
Changes as requested on #2717

### DIFF
--- a/allsky.sh
+++ b/allsky.sh
@@ -260,6 +260,9 @@ CAPTURE="capture_${CAMERA_TYPE}"
 
 rm -f "${ALLSKY_NOTIFICATION_LOG}"	# clear out any notificatons from prior runs.
 
+# Clear up any flow timings
+"${ALLSKY_SCRIPTS}/flow-runner.py" --cleartimings
+
 # Run the main program - this is the main attraction...
 # Pass debuglevel on command line so the capture program knows if it should display debug output.
 "${ALLSKY_BIN}/${CAPTURE}" -debuglevel "${ALLSKY_DEBUG_LEVEL}" -config "${ARGS_FILE}"

--- a/scripts/modules/allsky_shared.py
+++ b/scripts/modules/allsky_shared.py
@@ -351,6 +351,12 @@ def dbUpdate(key, value):
     DBDATA[key] = value
     writeDB()
 
+def dbDeleteKey(key):
+    global DBDATA
+    if dbHasKey(key):
+        del DBDATA[key]
+        writeDB()
+    
 def dbHasKey(key):
     global DBDATA
     return (key in DBDATA)

--- a/variables.sh
+++ b/variables.sh
@@ -98,6 +98,11 @@ if [[ -z "${ALLSKY_VARIABLE_SET}" ]]; then
 	ALLSKY_MODULE_LOCATION="/opt/allsky"
 	ALLSKY_EXTRA="${ALLSKY_OVERLAY}/extra"
 
+	# Directories and files for the flow timer function
+	ALLSKY_FLOWTIMINGS="${ALLSKY_TMP}/flowtimings"
+	ALLSKY_FLOWTIMINGS_DAY="${ALLSKY_FLOWTIMINGS}/day-average"
+	ALLSKY_FLOWTIMINGS_NIGHT="${ALLSKY_FLOWTIMINGS}/night-average"
+
 	# Verion file and option branch file.
 	ALLSKY_VERSION_FILE="${ALLSKY_HOME}/version"
 	ALLSKY_BRANCH_FILE="${ALLSKY_HOME}/branch"


### PR DESCRIPTION
- Allow the number of images to process to optionally be passed as an argument (to flow_runner.py ?). The default can remain at 10.

>Added --flowtimerframes option to flow-runney.py Default is 10

- Add a variable to allsky/variables.sh to define the directory, e.g., ALLSKY_FLOWTIMINGS. This will make it easy for check_allsky.sh to find the directory.

>Added the following variables
>ALLSKY_FLOWTIMINGS="${ALLSKY_TMP}/flowtimings"
>ALLSKY_FLOWTIMINGS_DAY="${ALLSKY_FLOWTIMINGS}/day-average"
>ALLSKY_FLOWTIMINGS_NIGHT="${ALLSKY_FLOWTIMINGS}/night-average"

- How will check_allsky.sh know the names of the files? Should other variables be added, e.g., ALLSKY_FLOWTIMINGS_XXX ?

> See above

- allsky/allsky.sh should rm -fr "${ALLSKY_FLOWTIMINGS}" so we know any files are from the current instance of Allsky.

> New option --cleartimings added to flow-runner.py. This is called from allsky.sh to clear all timing data

- Please make times stored in the files in integer milliseconds.

> Values are now ints