### PR TITLE
src/Makefile: temporarily break dependency on patchsunwait

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -112,7 +112,7 @@ patchsunwait:
 	@patch -p1 -d sunwait-src/ < sunwait.patch
 	@touch patchsunwait
 
-sunwait: patchsunwait
+sunwait: ##################### patchsunwait
 	@echo `date +%F\ %R:%S` Building sunwait...
 	@$(MAKE) -C sunwait-src
 	@cp sunwait-src/sunwait .


### PR DESCRIPTION
It causes the make to fail.