### PR TITLE
Improvements to process locking

### DIFF
--- a/allsky.sh
+++ b/allsky.sh
@@ -195,10 +195,10 @@ fi
 rm -f "${ALLSKY_BAD_IMAGE_COUNT}"	# Start with no bad images
 
 # Clear out these files and allow the web server to write to it.
-: > "${ALLSKY_ABORTEDUPLOADS}"
-: > "${ALLSKY_ABORTEDTIMELAPSE}"
-sudo chgrp "${WEBSERVER_GROUP}" "${ALLSKY_ABORTEDUPLOADS}" "${ALLSKY_ABORTEDTIMELAPSE}"
-sudo chmod 664 "${ALLSKY_ABORTEDUPLOADS}" "${ALLSKY_ABORTEDTIMELAPSE}"
+rm -fr "${ALLSKY_ABORTS_DIR}"
+mkdir "${ALLSKY_ABORTS_DIR}"
+sudo chgrp "${WEBSERVER_GROUP}" "${ALLSKY_ABORTS_DIR}"
+sudo chmod 775 "${ALLSKY_ABORTS_DIR}"
 
 # Optionally display a notification image.
 if [[ $USE_NOTIFICATION_IMAGES -eq 1 ]]; then

--- a/scripts/darkCapture.sh
+++ b/scripts/darkCapture.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This file is "source"d into another.
-# "${CURRENT_IMAGE}" is the name of the current image we're working on and is passed to us.
+# "${CURRENT_IMAGE}" is the full pathname of the current image we're working on and is passed to us.
 ME2="$(basename "${BASH_SOURCE[0]}")"
 
 # Make sure the input file exists; if not, something major is wrong so exit.
@@ -14,49 +14,29 @@ if [[ ! -f ${CURRENT_IMAGE} ]]; then
 	exit 2
 fi
 
-# ${AS_TEMPERATURE_C} is passed to us by saveImage.sh, but may be null.
-# If ${AS_TEMPERATURE_C} is set, use it as the temperature, otherwise read the ${TEMPERATURE_FILE}.
-# If the ${TEMPERATURE_FILE} file doesn't exist, set the temperature to "n/a".
+# The extension on $CURRENT_IMAGE may not be $EXTENSION.
+DARK_EXTENSION="${CURRENT_IMAGE##*.}"
+
+DARKS_DIR="${ALLSKY_DARKS}"
+mkdir -p "${DARKS_DIR}"
 if [[ -z ${AS_TEMPERATURE_C} ]]; then
-	TEMPERATURE_FILE="${ALLSKY_TMP}/temperature.txt"
-	if [[ -s ${TEMPERATURE_FILE} ]]; then	# -s so we don't use an empty file
-		AS_TEMPERATURE_C=$( < "${TEMPERATURE_FILE}")
-	else
-		AS_TEMPERATURE_C="n/a"
-	fi
+	# The camera doesn't support temperature so we'll keep overwriting the file until
+	# AS_TEMPERATURE_C is set.
+	# This allows users to continually look for a new dark file and rename it manually.
+	MOVE_TO_FILE="${DARKS_DIR}/$(basename "${CURRENT_IMAGE}")"
+else
+	MOVE_TO_FILE="${DARKS_DIR}/${AS_TEMPERATURE_C}.${DARK_EXTENSION}"
 fi
+mv "${CURRENT_IMAGE}" "${MOVE_TO_FILE}" || exit 3
 
-if [[ $(settings ".takeDarkFrames") -eq 1 ]]; then
-	# The extension on $CURRENT_IMAGE may not be $EXTENSION.
-	DARK_EXTENSION="${CURRENT_IMAGE##*.}"
+# If the user has notification images on, the current image says "Taking dark frames",
+# so don't overwrite it.
+# If notification images are off, let the user see the dark from to know it's working.
+# Some people may want to see the dark frame even if notification images
+# are being used, but no one's askef for that feature so don't worry about it.
 
-	DARKS_DIR="${ALLSKY_DARKS}"
-	mkdir -p "${DARKS_DIR}"
-	# If the camera doesn't support temperature, we will keep overwriting the file until
-	# the user creates a temperature.txt file.
-	if [[ ${AS_TEMPERATURE_C} == "n/a" ]]; then
-		MOVE_TO_FILE="${DARKS_DIR}/$(basename "${CURRENT_IMAGE}")"
-	else
-		MOVE_TO_FILE="${DARKS_DIR}/${AS_TEMPERATURE_C}.${DARK_EXTENSION}"
-	fi
-	mv "${CURRENT_IMAGE}" "${MOVE_TO_FILE}"
-
-	# If the user has notification images on, the current image says we're taking dark frames,
-	# so don't overwrite it.
-	# xxxx It's possible some people will want to see the dark frame even if notification images
-	# are being used - may need to make it optional to see the dark frame.
-	USE_NOTIFICATION_IMAGES=$(settings ".notificationimages")
-	if [[ ${USE_NOTIFICATION_IMAGES} -eq 0 ]]; then
-		# Go ahead and let the web sites see the dark frame to see if it's working.
-		# We're copying back the file we just moved, but the assumption is few people
-		# will want to see the dark frames on the web.
-
-		# xxxx  TODO: don't use $FULL_FILENAME since that assumes $EXTENSION is the same as
-		# $DARK_EXTENSION.  If we start saving darks as .png files the extensions will be
-		# different and we'll need to run "convert" to make the dark a .jpg file to
-		# be displayed on the web.
-		cp "${MOVE_TO_FILE}" "$(dirname "${CURRENT_IMAGE}")/${FULL_FILENAME}"
-	fi
-
-	exit 0	# exit so the calling script exits and doesn't try to process the file.
+if [[ $(settings ".notificationimages") -eq 0 ]]; then
+	# We're copying back the file we just moved, but the assumption is few people
+	# will want to see the dark frames so the performance hit is 
+	cp "${MOVE_TO_FILE}" "${ALLSKY_TMP}/${FILENAME}.${EXTENSION}"
 fi

--- a/scripts/endOfNight.sh
+++ b/scripts/endOfNight.sh
@@ -56,11 +56,11 @@ fi
 if [[ ${KEOGRAM} == "true" ]]; then
 	echo -e "${ME}: ===== Generating Keogram"
 	#shellcheck disable=SC2086
-	"${ALLSKY_SCRIPTS}/generateForDay.sh" ${NICE_ARG} --silent -k "${DATE}"
+	"${ALLSKY_SCRIPTS}/generateForDay.sh" ${NICE_ARG} --silent --keogram "${DATE}"
 	RET=$?
 	echo -e "${ME}: ===== Keogram complete"
 	if [[ ${UPLOAD_KEOGRAM} == "true" && ${RET} = 0 ]] ; then
-		"${ALLSKY_SCRIPTS}/generateForDay.sh" --upload -k "${DATE}"
+		"${ALLSKY_SCRIPTS}/generateForDay.sh" --upload --keogram "${DATE}"
 	fi
 fi
 
@@ -69,11 +69,11 @@ fi
 if [[ ${STARTRAILS} == "true" ]]; then
 	echo -e "${ME}: ===== Generating Startrails"
 	#shellcheck disable=SC2086
-	"${ALLSKY_SCRIPTS}/generateForDay.sh" ${NICE_ARG} --silent -s "${DATE}"
+	"${ALLSKY_SCRIPTS}/generateForDay.sh" ${NICE_ARG} --silent --startrails "${DATE}"
 	RET=$?
 	echo -e "${ME}: ===== Startrails complete"
 	if [[ ${UPLOAD_STARTRAILS} == "true" && ${RET} = 0 ]] ; then
-		"${ALLSKY_SCRIPTS}/generateForDay.sh" --upload -s "${DATE}"
+		"${ALLSKY_SCRIPTS}/generateForDay.sh" --upload --startrails "${DATE}"
 	fi
 fi
 
@@ -83,11 +83,11 @@ fi
 if [[ ${TIMELAPSE} == "true" ]]; then
 	echo -e "${ME}: ===== Generating Timelapse"
 	#shellcheck disable=SC2086
-	"${ALLSKY_SCRIPTS}/generateForDay.sh" ${NICE_ARG} --silent -t "${DATE}"
+	"${ALLSKY_SCRIPTS}/generateForDay.sh" ${NICE_ARG} --silent --timelapse "${DATE}"
 	RET=$?
 	echo -e "${ME}: ===== Timelapse complete"
 	if [[ ${UPLOAD_VIDEO} == "true" && ${RET} = 0 ]] ; then
-		"${ALLSKY_SCRIPTS}/generateForDay.sh" --upload -t "${DATE}"
+		"${ALLSKY_SCRIPTS}/generateForDay.sh" --upload --timelapse "${DATE}"
 	fi
 fi
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -694,3 +694,15 @@ function one_instance()
 
 	return 0
 }
+
+
+#####
+# Make a thumbnail image.
+function make_thumbnail()
+{
+	local SEC="${1}"
+	local INPUT_FILE="${2}"
+	local THUMBNAIL="${3}"
+	ffmpeg -loglevel error -ss "00:00:${SEC}" -i "${INPUT_FILE}" \
+		-filter:v scale="${THUMBNAIL_SIZE_X:-100}:-1" -frames:v 1 "${THUMBNAIL}"
+}

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -566,12 +566,13 @@ function one_instance()
 {
 	local SLEEP_TIME="5s"
 	local MAX_CHECKS=3
-	local PROCESS_NAME=""
 	local PID_FILE=""
 	local ABORTED_FILE=""
 	local ABORTED_FIELDS=""
 	local ABORTED_MSG1=""
 	local ABORTED_MSG2=""
+	local CAUSED_BY=""
+	local P=""
 
 	OK="true"
 	local ERRORS=""
@@ -584,10 +585,6 @@ function one_instance()
 					;;
 				--max-checks)
 					MAX_CHECKS=${2}
-					shift
-					;;
-				--process-name)
-					PROCESS_NAME="${2}"
 					shift
 					;;
 				--pid-file)
@@ -610,6 +607,10 @@ function one_instance()
 					ABORTED_MSG2="${2}"
 					shift
 					;;
+				--caused-by)
+					CAUSED_BY="${2}"
+					shift
+					;;
 				*)
 					ERRORS="${ERRORS}\nUnknown argument: '${ARG}'."
 					OK="false"
@@ -617,10 +618,6 @@ function one_instance()
 		esac
 		shift
 	done
-	if [[ -z ${PROCESS_NAME} ]]; then
-		ERRORS="${ERRORS}\nPROCESS_NAME not specified."
-		OK="false"
-	fi
 	if [[ -z ${PID_FILE} ]]; then
 		ERRORS="${ERRORS}\nPID_FILE not specified."
 		OK="false"
@@ -641,6 +638,7 @@ function one_instance()
 		ERRORS="${ERRORS}\nABORTED_MSG2 not specified."
 		OK="false"
 	fi
+	# CAUSED_BY isn't required
 
 	if [[ ${OK} == "false" ]]; then
 		echo -e "${RED}${ME}: ERROR: ${ERRORS}.${NC}" >&2
@@ -652,11 +650,12 @@ function one_instance()
 	while  : ; do
 		[[ ! -f ${PID_FILE} ]] && break
 
+		((NUM_CHECKS++))
+
 		PID=$( < "${PID_FILE}" )
-		# shellcheck disable=SC2009
-		if ! ps -fp "${PID}" | /bin/grep --silent "${PROCESS_NAME}" ; then
-			break	# Not sure why the PID file existed if the process didn't exist.
-		fi
+		# Check that the process is still running.
+		P="$( ps -fp "${PID}" )"
+		[[ $? -ne 0 ]] && break;	# not running - why is the file still here?
 
 		if [[ $NUM_CHECKS -eq ${MAX_CHECKS} ]]; then
 			echo -en "${YELLOW}" >&2
@@ -664,21 +663,23 @@ function one_instance()
 			echo -n  "Made ${NUM_CHECKS} attempts at waiting." >&2
 			echo -n  " If this happens often, check your settings." >&2
 			echo -e  "${NC}" >&2
-			ps -fp "${PID}" >&2
+			echo "${P}" >&2
 
 			# Keep track of aborts so user can be notified.
 			# If it's happening often let the user know.
-			echo -e "$(date)\t${ABORTED_FIELDS}" >> "${ABORTED_FILE}"
-			NUM=$( wc -l < "${ABORTED_FILE}" )
+			[[ ! -d ${ALLSKY_ABORTS_DIR} ]] && mkdir "${ALLSKY_ABORTS_DIR}"
+			local AF="${ALLSKY_ABORTS_DIR}/${ABORTED_FILE}"
+			echo -e "$(date)\t${ABORTED_FIELDS}" >> "${AF}"
+			NUM=$( wc -l < "${AF}" )
 			if [[ ${NUM} -eq 3 || ${NUM} -eq 10 ]]; then
 				MSG="${NUM} ${ABORTED_MSG2} have been aborted waiting for others to finish."
-				MSG="${MSG}\nThis could be caused by a slow network or other network issues."
+				[[ -n ${CAUSED_BY} ]] && MSG="${MSG}\n${CAUSED_BY}"
 				if [[ ${NUM} -eq 3 ]]; then
 					SEVERITY="info"
 				else
 					SEVERITY="warning"
 					MSG="${MSG}\nOnce you have resolved the cause, reset the aborted counter:"
-					MSG="${MSG}\n&nbsp; &nbsp; <code>rm -f '${ABORTED_FILE}'</code>"
+					MSG="${MSG}\n&nbsp; &nbsp; <code>rm -f '${AF}'</code>"
 				fi
 				"${ALLSKY_SCRIPTS}/addMessage.sh" "${SEVERITY}" "${MSG}"
 			fi
@@ -687,7 +688,6 @@ function one_instance()
 		else
 			sleep "${SLEEP_TIME}"
 		fi
-		((NUM_CHECKS++))
 	done
 
 	echo $$ > "${PID_FILE}" || return 1

--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -58,8 +58,7 @@ ABORTED_MSG2="uploads"
 CAUSED_BY="This could be caused by very long module processing time or extremely short delays between images."
 # Don't sleep too long or check too many times since processing an image should take at most
 # a few seconds
-if ! one_instance --process-name "${ME}" --pid-file "${PID_FILE}" \
-		--sleep "3s" --max-checks 3 \
+if ! one_instance --pid-file "${PID_FILE}" --sleep "3s" --max-checks 3 \
 		--aborted-count-file "${ALLSKY_ABORTEDSAVEIMAGE}" --aborted-fields "${ABORTED_FIELDS}" \
 		--aborted-msg1 "${ABORTED_MSG1}" --aborted-msg2 "${ABORTED_MSG2}" \
 		--caused-by "${CAUSED_BY}" ; then

--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -350,8 +350,8 @@ if [[ ${SAVE_IMAGE} == "true" ]]; then
 				else
 					D=""
 				fi
-				# shellcheck disable=SC2086
 				O="${ALLSKY_TMP}/mini-timelapse.mp4"
+				# shellcheck disable=SC2086
 				"${ALLSKY_SCRIPTS}"/timelapse.sh ${D} --lock --output "${O}" \
 					--mini --images "${MINI_TIMELAPSE_FILES}"
 				RET=$?

--- a/scripts/timelapse.sh
+++ b/scripts/timelapse.sh
@@ -194,7 +194,7 @@ if [[ ${KEEP_SEQUENCE} == "false" ]]; then
 				fi
 			else
 				((NUM_IMAGES++))
-				NUM="$( printf "%04d" ${NUM_IMAGES} )"
+				NUM="$( printf "%04d" "${NUM_IMAGES}" )"
 				ln -s "${IMAGE}" "${SEQUENCE_DIR}/${NUM}.${EXTENSION}"
 			fi
 		done

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -126,10 +126,11 @@ ABORTED_MSG1="Another '${FILE_TYPE}' upload is in progress so the new upload of"
 ABORTED_MSG1="${ABORTED_MSG1} $(basename "${FILE_TO_UPLOAD}") was aborted."
 ABORTED_FIELDS="${FILE_TYPE}\t${FILE_TO_UPLOAD}"
 ABORTED_MSG2="uploads"
-if ! one_instance --sleep "${SLEEP}" --max-checks "${MAX_CHECKS}" \
-		--process-name "${ME}" --pid-file "${PID_FILE}" \
+CAUSED_BY="This could be caused network issues or by delays between images that are too short."
+if ! one_instance --sleep "${SLEEP}" --max-checks "${MAX_CHECKS}" --pid-file "${PID_FILE}" \
 		--aborted-count-file "${ALLSKY_ABORTEDUPLOADS}" --aborted-fields "${ABORTED_FIELDS}" \
-		--aborted-msg1 "${ABORTED_MSG1}" --aborted-msg2 "${ABORTED_MSG2}" ; then
+		--aborted-msg1 "${ABORTED_MSG1}" --aborted-msg2 "${ABORTED_MSG2}" \
+		--caused-by "${CAUSED_BY}" ; then
 	exit 1
 fi
 

--- a/variables.sh
+++ b/variables.sh
@@ -83,9 +83,10 @@ if [[ -z "${ALLSKY_VARIABLE_SET}" ]]; then
 	POST_INSTALLATION_ACTIONS="${ALLSKY_INSTALLATION_LOGS}/post-installation_actions.txt"
 
 	# Holds temporary list of aborted processes since another one was in progress.
-	ALLSKY_ABORTEDUPLOADS="${ALLSKY_TMP}/aborts/uploads.txt"
-	ALLSKY_ABORTEDTIMELAPSE="${ALLSKY_TMP}/aborts/timelapse.txt"
-	ALLSKY_ABORTEDSAVEIMAGE="${ALLSKY_TMP}/aborts/saveImage.txt"
+	ALLSKY_ABORTS_DIR="${ALLSKY_TMP}/aborts"
+	ALLSKY_ABORTEDUPLOADS="uploads.txt"
+	ALLSKY_ABORTEDTIMELAPSE="timelapse.txt"
+	ALLSKY_ABORTEDSAVEIMAGE="saveImage.txt"
 
 	# Holds all the dark frames.
 	ALLSKY_DARKS="${ALLSKY_HOME}/darks"

--- a/variables.sh
+++ b/variables.sh
@@ -83,9 +83,9 @@ if [[ -z "${ALLSKY_VARIABLE_SET}" ]]; then
 	POST_INSTALLATION_ACTIONS="${ALLSKY_INSTALLATION_LOGS}/post-installation_actions.txt"
 
 	# Holds temporary list of aborted processes since another one was in progress.
-	ALLSKY_ABORTEDUPLOADS="${ALLSKY_TMP}/aborted_uploads.txt"
-	ALLSKY_ABORTEDTIMELAPSE="${ALLSKY_TMP}/aborted_timelapse.txt"
-	ALLSKY_ABORTEDSAVEIMAGE="${ALLSKY_TMP}/aborted_saveImage.txt"
+	ALLSKY_ABORTEDUPLOADS="${ALLSKY_TMP}/aborts/uploads.txt"
+	ALLSKY_ABORTEDTIMELAPSE="${ALLSKY_TMP}/aborts/timelapse.txt"
+	ALLSKY_ABORTEDSAVEIMAGE="${ALLSKY_TMP}/aborts/saveImage.txt"
 
 	# Holds all the dark frames.
 	ALLSKY_DARKS="${ALLSKY_HOME}/darks"


### PR DESCRIPTION
* Improve the way process locking is done and the aborted messages.
* The files listing the aborted processes are all in a sub-directory in allsky/tmp.
* Create a global make_thumbnail() function rather than using the one defined in a scripts/*.sh file.  More scripts will use this via another PR.
* Many other changes that aren't related to process locking, but hey, I was already editing the files...