### PR TITLE
functions.sh: Don't do "ls -l" of FILE

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -445,8 +445,7 @@ function settings()
 		return 0
 	fi
 
-	echo "${M}: Unable to get json value for '${FIELD}'." >&2
-	ls -l "${FILE}" >&2
+	echo "${M}: Unable to get json value for '${FIELD}' in '${FILE}." >&2
 	
 	return 2
 }


### PR DESCRIPTION
Often the jq fails because FILE doesn't exist, and jq outputs that error so there's no need to do "ls" of the file since it will also fail.