### PR TITLE
removeBadImages.sh: shorten message so it fits in image

### DIFF
--- a/scripts/removeBadImages.sh
+++ b/scripts/removeBadImages.sh
@@ -235,7 +235,7 @@ else
 				--directory "${ALLSKY_TMP}" \
 				"${FILENAME}" "yellow" "" "85" "" "" \
 	 			"" "5" "yellow" "${EXTENSION}" "" \
-				"WARNING:\n\n${BAD_COUNT} consecutive\nbad images. See:\n${DIR}/\n  ${FILE}" >&2
+				"WARNING:\n${BAD_COUNT} consecutive\nbad images. See:\n${DIR}/\n  ${FILE}" >&2
 
 		fi
 


### PR DESCRIPTION
The "X consecutive..." message doesn't quite fit in the screen so remove a newline.