### PR TITLE
Fixes for font uploads #2884

### DIFF
--- a/html/includes/overlay.php
+++ b/html/includes/overlay.php
@@ -727,6 +727,9 @@ function DisplayOverlay($image_name)
                     </div>
                     <div class="modal-body">
                         <div>
+                            <div style="margin: 10px;">
+                                <h4>Please refer to the <a href="/documentation/overlays/overlays.html" target="_blank">documentation</a> before uploading zip files. Please ensure the zip file only contains fonts</h4>
+                            </div>
                             <div class="alert alert-danger hidden" id="fontuploadalert">
                                 <strong>Error!</strong> Unable to upload the zip file. Invalid Signature for font file
                             </div>

--- a/html/includes/overlayutil.php
+++ b/html/includes/overlayutil.php
@@ -466,58 +466,61 @@ class OVERLAYUTIL
                 $validExtenstions = array("ttf", "otf");
                 $validSignatures = array("00010000", "4F54544F");
 
-                if (in_array($ext, $validExtenstions)) {
-                    $fp = $zipArchive->getStream($nameInArchive);
-                    if (!$fp) {
-                        exit("failed\n");
-                    }
-
-                    $contents = '';
-                    while (!feof($fp)) {
-                        $contents .= fread($fp, 1024);
-                    }
-                    fclose($fp);
-
-                    $cleanFileName = basename(str_replace(' ', '', $nameInArchive));
-                    $fileName = $saveFolder . $cleanFileName;
-                    $sig = substr($contents,0,4);
-                    $sig = bin2hex($sig);
-                    if (in_array($sig, $validSignatures)) {
-                        $file = fopen($fileName, 'wb');
-
-                        if ($file = fopen($fileName, 'wb')) {
-                            fwrite($file, $contents);
-                            fclose($file);
-
-                            $configFileName = $this->overlayPath . '/config/overlay.json';
-                            $config = file_get_contents($configFileName);
-                            $config = json_decode($config);
-
-                            $fontPath = str_replace($this->overlayPath, "", $fileName);
-                            // TODO: Fix hard coded path
-                            $obj = (object) [
-                                'fontPath' => $fontPath,
-                            ];
-
-                            $key = strtolower(basename($fileName));
-                            $key = str_replace($validExtenstions, "", $key);
-                            $key = str_replace(".", "", $key);
-                            $config->fonts->$key = $obj;
-                            $formattedJSON = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-
-                            file_put_contents($configFileName, $formattedJSON);
-
-                            $result[] = array(
-                                'key' => $key,
-                                'path' => $fontPath,
-                            );
-                        } else {
-                            die('cant create file ' . $fileName);
+                if (strpos($nameInArchive, "MACOSX") === false) {
+                    if (in_array($ext, $validExtenstions)) {
+                        $fp = $zipArchive->getStream($nameInArchive);
+                        if (!$fp) {
+                            exit("failed\n");
                         }
-                    } else {
-                        $this->send500();
+
+                        $contents = '';
+                        while (!feof($fp)) {
+                            $contents .= fread($fp, 1024);
+                        }
+                        fclose($fp);
+
+                        $cleanFileName = basename(str_replace(' ', '', $nameInArchive));
+                        $fileName = $saveFolder . $cleanFileName;
+                        $sig = substr($contents,0,4);
+                        $sig = bin2hex($sig);
+                        if (in_array($sig, $validSignatures)) {
+                            $file = fopen($fileName, 'wb');
+
+                            if ($file = fopen($fileName, 'wb')) {
+                                fwrite($file, $contents);
+                                fclose($file);
+
+                                $configFileName = $this->overlayPath . '/config/overlay.json';
+                                $config = file_get_contents($configFileName);
+                                $config = json_decode($config);
+
+                                $fontPath = str_replace($this->overlayPath, "", $fileName);
+                                // TODO: Fix hard coded path
+                                $obj = (object) [
+                                    'fontPath' => $fontPath,
+                                ];
+
+                                $key = strtolower(basename($fileName));
+                                $key = str_replace($validExtenstions, "", $key);
+                                $key = str_replace(".", "", $key);
+                                $config->fonts->$key = $obj;
+                                $formattedJSON = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+                                file_put_contents($configFileName, $formattedJSON);
+
+                                $result[] = array(
+                                    'key' => $key,
+                                    'path' => $fontPath,
+                                );
+                            } else {
+                                die('cant create file ' . $fileName);
+                            }
+                        } else {
+                            $this->send500();
+                        }
                     }
                 }
+
             }
             echo (json_encode($result));
         } else {


### PR DESCRIPTION
- Prevent files on osx zip files from confusing the font uploader
- Add message to get people to read the documentation before uploading zip files