### PR TITLE
fixes for font and field defaults #2886

### DIFF
--- a/html/js/overlay/fields/oe-field.js
+++ b/html/js/overlay/fields/oe-field.js
@@ -30,6 +30,22 @@ class OEFIELD {
     }
   }
 
+  updateDefaults() {
+    for (let defaultName in this.DEFAULTS) {
+      let path = this.DEFAULTS[defaultName].path;
+      let defaultPath = this.DEFAULTS[defaultName].defaultpath;
+      let defaultValue = this.DEFAULTS[defaultName].default;
+
+      if (path in this.fieldData) {
+        let oldDefault = this.config.getBackupValue(defaultPath, defaultValue);
+        if (this.fieldData[path] == oldDefault) {
+          this.fieldData[path] = this.config.getValue(defaultPath, defaultValue);
+          this[path] = this.fieldData[path] ;
+        }
+      }      
+    }
+  }
+
   get id() {
     return this.id;
   }

--- a/html/js/overlay/fields/oe-fieldmanager.js
+++ b/html/js/overlay/fields/oe-fieldmanager.js
@@ -162,6 +162,12 @@ class OEFIELDMANAGER {
         this.#fieldDeletedAddedDefaultsChanged = true;
     }
 
+    updateFieldDefaults() {
+        for (let [fieldName, field] of this.#fields.entries()) {
+            field.updateDefaults();
+        }
+    }
+
     buildJSON() {
         let fields = [];
         let images = [];

--- a/html/js/overlay/fields/oe-text.js
+++ b/html/js/overlay/fields/oe-text.js
@@ -131,6 +131,16 @@ class OETEXTFIELD extends OEFIELD {
     this.dirty = true;
   }
 
+  // Following getter and setter are neeed as font should be fontFamily in the defaults
+  get font() {
+    return this.fieldData.font;
+  }
+  set font(font) {
+    this.fieldData.font = font;
+    this.shape.fontFamily(font);
+    this.dirty = true;
+  }
+
   get fontname() {
     return this.fieldData.font;
   }

--- a/html/js/overlay/oe-config.js
+++ b/html/js/overlay/oe-config.js
@@ -7,6 +7,8 @@ class OECONFIG {
     #overlayDataFields = {};
     #BASEDIR = 'annotater/';
 
+    #lastConfig = [];
+
     constructor() {
     }
 
@@ -164,6 +166,10 @@ class OECONFIG {
         return this.#dataFields = dataFields;
     }
 
+    backupConfig() {
+        this.#lastConfig= JSON.parse(JSON.stringify(this.#config));
+    }
+
     saveFields() {
         try {
             $.ajax({
@@ -306,6 +312,10 @@ class OECONFIG {
      */
     getValue(path, defaultValue) {
         return path.split('.').reduce((o, p) => o ? o[p] : defaultValue, this.#config);
+    }
+
+    getBackupValue(path, defaultValue) {
+        return path.split('.').reduce((o, p) => o ? o[p] : defaultValue, this.#lastConfig);
     }
 
     /**

--- a/html/js/overlay/oe-uimanager.js
+++ b/html/js/overlay/oe-uimanager.js
@@ -907,7 +907,7 @@ class OEUIMANAGER {
             let defaultStrokeColour = $('#oe-default-stroke-colour').val();
             let defaultStrokeSize = $('#oe-default-stroke-size').val();
 
-
+            this.#configManager.backupConfig();
             this.#configManager.setValue('settings.defaultimagetopacity', defaultImagOpacity);
             this.#configManager.setValue('settings.defaultimagerotation', defaultImagRotation);
             this.#configManager.setValue('settings.defaultfontsize', defaultFontSize);
@@ -934,6 +934,7 @@ class OEUIMANAGER {
             this.#configManager.mouseWheelZoom = $('#oe-app-options-mousewheel-zoom').prop('checked');
             this.#configManager.backgroundImageOpacity = $('#oe-app-options-background-opacity').val() | 0;
 
+            this.#fieldManager.updateFieldDefaults();
             this.drawGrid();
             this.updateBackgroundImage();
 

--- a/scripts/modules/allsky_overlay.py
+++ b/scripts/modules/allsky_overlay.py
@@ -624,10 +624,7 @@ class ALLSKYOVERLAY:
         try:
             r,g,b = ImageColor.getcolor(value, "RGB")
         except:
-            if value == "":
-                s.log(0, "ERROR: The colour for field '{0}' is empty - Defaulting to white.".format(name))
-            else:
-                s.log(0, "ERROR: The colour '{0}' for field '{1}' is NOT valid - Defaulting to white.".format(value, name))
+            s.log(0, f"ERROR: The colour '{value}' for field '{name}' is NOT valid - Defaulting to white.")
             r = 255
             g = 255
             b = 255


### PR DESCRIPTION
Fixes for

- Colour error in the allsky.log file
- Changes to defaults in the overlay editor are now correctly reflected in any fields using the defaults. Note this applies to ALL defaults not just the colours