### PR TITLE
Fix for Python dependencies

### DIFF
--- a/config_repo/requirements.txt
+++ b/config_repo/requirements.txt
@@ -1,4 +1,4 @@
-numpy<=1.24.2
+numpy>=1.25.0
 opencv-python<=4.6.0.66
 Pillow
 pyephem


### PR DESCRIPTION
Fix for Python dependencies on 32 bit Bullseye

Tested on 32 Bit Bullseye Lite and Desktop, 64 Bit Desktop
