### PR TITLE
Rename settings_str to website_settings_str

### DIFF
--- a/html/allsky/functions.php
+++ b/html/allsky/functions.php
@@ -31,17 +31,18 @@ if (! file_exists($configuration_file)) {
 	echo "</p>";
 	exit;
 }
-$settings_str = file_get_contents($configuration_file, true);
-$settings_array = json_decode($settings_str, true);
-if ($settings_array == null) {
+$website_settings_str = file_get_contents($configuration_file, true);
+$website_settings_array = json_decode($website_settings_str, true);
+if ($website_settings_array == null) {
 	echo "<p style='color: red; font-size: 200%'>";
 	echo "ERROR: Bad configuration file '<span style='color: black'>$configurationFileName</span>'.  Cannot continue.";
 	echo "<br>Check for missing quotes or commas at the end of every line (except the last one).";
 	echo "</p>";
-	echo "<pre>$settings_str</pre>";
+	echo "<pre>$website_settings_str</pre>";
 	exit;
 }
-$onPi = v("onPi", true, $settings_array['homePage']);
+$onPi = v("onPi", true, $website_settings_array['homePage']);
+
 
 /*
  * Does the exec() function work?  It's needed to make thumbnails from video files.
@@ -250,7 +251,14 @@ function display_thumbnails($dir, $file_prefix, $title)
 	echo "<table class='imagesHeader'><tr><td class='headerButton'>$back_button</td> <td class='headerTitle'>$title</td></tr></table>";
 	echo "<div class='archived-files'>\n";
 
-	$thumbnailSizeX = get_variable(ALLSKY_CONFIG .'/config.sh', 'THUMBNAIL_SIZE_X=', '100');
+	$thumbnailSizeX = 100;
+	$s = "viewSettings/settings.json";
+	if (file_exists($s)) {
+		$errorMsg = "<br>Unable to read $s";
+		$settings_array = get_decoded_json_file($s, false, $errorMsg);
+		if (isset($settings_array['thumbnailsizex']))
+			$thumbnailSizeX = $settings_array['thumbnailsizex'];
+	}
 	foreach ($files as $file) {
 		// The thumbnail should be a .jpg.
 		$thumbnail = preg_replace($ext, ".jpg", "$dir/thumbnails/$file");

--- a/html/allsky/index.php
+++ b/html/allsky/index.php
@@ -37,10 +37,10 @@
 	<?php
 		// This gets the settings.
 		// Some settings impact this page, some impact the constellation overlay.
-		include_once('functions.php');		// Sets $settings_array
+		include_once('functions.php');		// Sets $website_settings_array
 
 		// Get home page options
-		$homePage = v("homePage", null, $settings_array);
+		$homePage = v("homePage", null, $website_settings_array);
 			// TODO: replace double quotes with &quot; in any variable that can be in an HTML attribute,
 			// which is many of them.
 			$backgroundImage = v("backgroundImage", "", $homePage);
@@ -87,7 +87,7 @@
 		// Get javascript config variable options.
 		// To avoid changing too much code, the "config" javascript variable is created
 		// here to replace the old config.js file that contained that variable.
-		$config = v("config", null, $settings_array);
+		$config = v("config", null, $website_settings_array);
 		$imageWidth = v("imageWidth", null, $config);
 			echo "<script>config = {\n";
 			foreach ($config as $var => $val) {	// ok to have comma after last entry

--- a/html/allsky/show_thumbnails.php
+++ b/html/allsky/show_thumbnails.php
@@ -1,14 +1,14 @@
 <?php
 	$configFilePrefix = "../";
 	include_once('functions.php'); disableBuffering();	 // must be first line
-	// Settings are now in $settings_array.
+	// Settings are now in $website_settings_array.
 
 	if (! isset($dir) || ! isset($prefix) || ! isset($title)) {
 		echo "<p>INTERNAL ERROR: incomplete arguments given to view thumbnails.</p>";
 		echo "dir, prefix, and/or title missing.";
 		exit;
 	}
-	$homePage = v("homePage", null, $settings_array);
+	$homePage = v("homePage", null, $website_settings_array);
 	$includeGoogleAnalytics = v("includeGoogleAnalyticsx", false, $homePage);
 ?>
 <!DOCTYPE html>

--- a/html/includes/allskySettings.php
+++ b/html/includes/allskySettings.php
@@ -368,7 +368,9 @@ if ($debug) { echo "<pre>"; var_dump($content); echo "</pre>"; }
 	}
 
 	// If the settings file changed above, re-read the file.
-	if (isset($_POST['save_settings']) || isset($_POST['reset_settings'])) {
+	// Also, if $settings_array is null it means we're being called from the Allsky Website,
+	// so read the file.
+	if (isset($_POST['save_settings']) || isset($_POST['reset_settings']) || $settings_array === null) {
 		$errorMsg = "ERROR: Unable to process settings file '$settings_file'.";
 		$settings_array = get_decoded_json_file($settings_file, true, $errorMsg);
 		if ($settings_array === null) {


### PR DESCRIPTION
The Website and WebUI both use "settings_str" and "settings_array" to refer to their settings file, but the settings files are different - configuration.json for the Website and setting.json for the WebUI.
Since the WebUI "allskySettings.php" page can use "functions.php" from the Website we need to distinguish between the settings files.