### PR TITLE
Copy python dependencies during upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2325,6 +2325,15 @@ install_overlay()
 				activate_python_venv
 			fi
 
+			# AG - Temporary fix to ensure that all dependencies are available for the Allsky modules
+			# as the flow upgrader needs to load each module and if the dependencies are missing this will
+			# fail
+			if [[ -d "${ALLSKY_PYTHON_VENV}" ]]; then
+				if [[ -d "${PRIOR_ALLSKY_DIR}/venv/lib" ]]; then
+					cp -arn "${PRIOR_ALLSKY_DIR}/venv/lib" "${ALLSKY_PYTHON_VENV}/"
+				fi
+			fi
+
 			local TMP="${ALLSKY_INSTALLATION_LOGS}/${NAME}"
 			display_msg --log progress "Installing ${NAME}${M}:"
 			local COUNT=0


### PR DESCRIPTION
Copies python dependencies from an old allsky installation during an upgrade. This is required to ensure that the flow upgrader can load the python modules