### PR TITLE
Add archived images upload and gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ config/
 env.json
 variables.json
 html/allsky/configuration.json
+html/allsky/images/[0-9][0-9][0-9][0-9]/
 html/allsky/viewSettings/
 scripts/allsky-config
 scripts/functions.php

--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -1475,6 +1475,16 @@
 "booldependson" : "timelapsegenerate AND timelapseupload AND (uselocalwebsite OR useremotewebsite OR useremoteserver)"
 },
 {
+"name" : "uploadimages",
+"default" : false,
+"description" : "Enable to upload all images from the day to an Allsky Website and/or remote server in images/YYYY/YYYYMMDD/ format.",
+"label" : "Upload Images",
+"label_prefix" : "Daily Timelapse",
+"type" : "boolean",
+"carryforward" : true,
+"booldependson" : "timelapsegenerate AND (uselocalwebsite OR useremotewebsite OR useremoteserver)"
+},
+{
 "name" : "keogramupload",
 "default" : true,
 "description" : "Enable to upload the keogram to an Allsky Website and/or remote server.",

--- a/html/allsky/images/index.php
+++ b/html/allsky/images/index.php
@@ -1,0 +1,202 @@
+<?php
+$configFilePrefix = "../";
+include_once('../functions.php'); 
+disableBuffering();
+
+// Settings are now in $webSettings_array.
+$homePage = v("homePage", null, $webSettings_array);
+$includeGoogleAnalytics = v("includeGoogleAnalytics", false, $homePage);
+$thumbnailsortorder = v("thumbnailsortorder", "descending", $homePage);
+$thumbnailSizeX = v("thumbnailsizex", 100, $homePage);
+
+// Get date from URL or use today
+$selected_date = isset($_GET['date']) ? $_GET['date'] : date('Ymd');
+if (!preg_match('/^\d{8}$/', $selected_date)) {
+	$selected_date = date('Ymd');
+}
+
+$title = "Archived Images";
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta http-equiv="Content-Type" content="text/html" />
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="shortcut icon" type="image/png" href="../allsky-favicon.png">
+	<title><?php echo $title; ?></title>
+
+<?php 
+	if ($includeGoogleAnalytics && file_exists("../js/analyticsTracking.js")) {
+		echo "<script src='../js/analyticsTracking.js'></script>";
+	}
+?>
+	<link href="../font-awesome/css/all.min.css" rel="stylesheet">
+	<link href="../css/allsky.css" rel="stylesheet">
+	<style>
+		.date-controls {
+			margin: 20px 0;
+			padding: 15px;
+			background: #222;
+			border-radius: 5px;
+			display: flex;
+			gap: 10px;
+			align-items: center;
+			flex-wrap: wrap;
+		}
+		.date-input {
+			background: #333;
+			border: 1px solid #555;
+			color: #e0e0e0;
+			padding: 8px 12px;
+			border-radius: 4px;
+			font-size: 14px;
+		}
+		.btn-date {
+			background: #7777ff;
+			color: white;
+			border: none;
+			padding: 8px 16px;
+			border-radius: 4px;
+			cursor: pointer;
+			font-size: 14px;
+		}
+		.btn-date:hover {
+			background: #6666ee;
+		}
+		.date-info {
+			color: #7777ff;
+			font-weight: bold;
+		}
+	</style>
+</head>
+<body>
+
+<?php
+// Calculate dates for navigation
+$date_obj = DateTime::createFromFormat('Ymd', $selected_date);
+$prev_date = clone $date_obj;
+$prev_date->modify('-1 day');
+$next_date = clone $date_obj;
+$next_date->modify('+1 day');
+
+$year = substr($selected_date, 0, 4);
+$month = substr($selected_date, 4, 2);
+$day = substr($selected_date, 6, 2);
+$formatted_date = "$year-$month-$day ({$date_obj->format('l')})";
+
+// Build directory path
+$dir = "./$year/$selected_date";
+
+// Get list of images
+$images = array();
+if (is_dir($dir)) {
+	$files = glob("$dir/*.{jpg,JPG,jpeg,JPEG}", GLOB_BRACE);
+	foreach ($files as $file) {
+		$images[] = basename($file);
+	}
+	
+	if ($thumbnailsortorder === "descending") {
+		arsort($images);
+	} else {
+		asort($images);
+	}
+}
+
+$num_images = count($images);
+?>
+
+	<div class="date-controls">
+		<button class="btn-date" onclick="navigateToDate('<?php echo $prev_date->format('Ymd'); ?>')">
+			<i class="fas fa-chevron-left"></i> Previous
+		</button>
+		
+		<input type="date" 
+			   class="date-input" 
+			   value="<?php echo $date_obj->format('Y-m-d'); ?>"
+			   onchange="navigateToDate(this.value.replace(/-/g, ''))">
+		
+		<button class="btn-date" onclick="navigateToDate('<?php echo $next_date->format('Ymd'); ?>')">
+			Next <i class="fas fa-chevron-right"></i>
+		</button>
+		
+		<button class="btn-date" onclick="navigateToDate('<?php echo date('Ymd'); ?>')">
+			<i class="fas fa-calendar-day"></i> Today
+		</button>
+		
+		<span class="date-info"><?php echo $formatted_date; ?> (<?php echo $num_images; ?> images)</span>
+	</div>
+
+<?php
+if ($num_images == 0) {
+	echo "<p>$back_button</p>";
+	echo "<div class='noImages'>No images for $formatted_date</div>";
+} else {
+	echo "<table class='imagesHeader'>";
+		echo "<tr>";
+			echo "<td class='headerButton'>$back_button</td>";
+			echo "<td class='headerTitle'>$title - $formatted_date</td>";
+		echo "</tr>";
+		echo "<tr>";
+			echo "<td colspan='2'><div class='imagesSortOrder'>$num_images images - ";
+			echo ($thumbnailsortorder === "descending") ? "Sorted newest to oldest" : "Sorted oldest to newest";
+			echo "</div></td>";
+		echo "</tr>";
+	echo "</table>";
+	
+	// Try to create thumbnails directory
+	$thumb_dir = "$dir/thumbnails";
+	$can_create_thumbs = false;
+	if (is_dir($thumb_dir)) {
+		$can_create_thumbs = true;
+	} else {
+		// Try to create with recursive flag
+		if (@mkdir($thumb_dir, 0775, true)) {
+			$can_create_thumbs = true;
+		}
+	}
+	
+	echo "<div class='archived-files'>\n";
+	
+	foreach ($images as $image) {
+		$image_path = "$dir/$image";
+		$thumbnail = "$thumb_dir/$image";
+		
+		// Use thumbnail if exists, otherwise try to create it, or use full image
+		if (file_exists($thumbnail)) {
+			$display_image = $thumbnail;
+		} else if ($can_create_thumbs && make_thumb($image_path, $thumbnail, $thumbnailSizeX)) {
+			$display_image = $thumbnail;
+			flush();
+		} else {
+			// Can't create thumbnail, use full image
+			$display_image = $image_path;
+		}
+		
+		// Extract time from filename (YYYYMMDD_HHMMSS.jpg)
+		$time = '';
+		if (preg_match('/\d{8}_(\d{2})(\d{2})(\d{2})/', $image, $matches)) {
+			$time = $matches[1] . ':' . $matches[2] . ':' . $matches[3];
+		}
+		
+		echo "<a href='$image_path'><div class='day-container'><div class='img-text'>";
+			echo "<div class='image-container'>";
+				echo "<img src='$display_image' title='$image'/>";
+			echo "</div>";
+			echo "<div class='day-text'>$time</div>";
+		echo "</div></div></a>\n";
+	}
+	
+	echo "</div>"; // archived-files
+	echo "<div class='archived-files-end'></div>";
+	echo "<div class='archived-files'><hr></div>";
+}
+?>
+
+<script>
+function navigateToDate(date) {
+	window.location.href = '?date=' + date;
+}
+</script>
+
+</body>
+</html>

--- a/html/includes/days.php
+++ b/html/includes/days.php
@@ -102,8 +102,17 @@ foreach ($days as $day) {
 		$i = getValidImageNames(ALLSKY_IMAGES . "/$day/meteors", true);	// true == stop after 1
 		$has_meteors = (count($i) > 0);
 	}
+	// Check for archived images in images/YYYY/YYYYMMDD/
+	$year = substr($day, 0, 4);
+	$archived_dir = ALLSKY_IMAGES . "/images/$year/$day";
+	$has_archived_images = false;
+	if (is_dir($archived_dir)) {
+		$ai = getValidImageNames($archived_dir, true);	// true == stop after 1
+		$has_archived_images = (count($ai) > 0);
+	}
 
-	if (! $has_images && ! $has_timelapse && ! $has_keogram && ! $has_startrails && ! $has_meteors) {
+
+	if (! $has_images && ! $has_timelapse && ! $has_keogram && ! $has_startrails && ! $has_meteors && ! $has_archived_images) {
 		echo "<script>console.log('Directory \"$day\" has no images, timelapse, et.al.; ignoring.');</script>";
 		continue;
 	}
@@ -119,6 +128,10 @@ foreach ($days as $day) {
 		echo "none";
 	}
 	echo "</td>\n";
+	if ($has_archived_images) {
+		$icon_archive = "<i class='fa fa-archive fa-{$fa_size} fa-fw' style='color:#888'></i>";
+		echo " <a href='index.php?page=list_images&day=$day&archived=1' title='Archived Images'>$icon_archive</a>";
+	}
 
 	echo "\t\t\t<td>";
 	if ($has_timelapse) {

--- a/html/includes/images.php
+++ b/html/includes/images.php
@@ -32,7 +32,22 @@ function ListImages() {
 		return;
 	}
 
-	$dir = ALLSKY_IMAGES . "/$chosen_day";
+	// Check if we should display archived images
+	$archived = getVariableOrDefault($_GET, 'archived', 0);
+	
+	if ($archived == 1) {
+		// Display from images/YYYY/YYYYMMDD/
+		$year = substr($chosen_day, 0, 4);
+		$dir = ALLSKY_IMAGES . "/images/$year/$chosen_day";
+		$web_path = "/images/images/$year/$chosen_day";
+		$title_suffix = " (Archived)";
+	} else {
+		// Display from regular day directory
+		$dir = ALLSKY_IMAGES . "/$chosen_day";
+		$web_path = "/images/$chosen_day";
+		$title_suffix = "";
+	}
+
 	$images = getValidImageNames($dir, false);	// false == get whole list
 	if (count($images) > 0) {
 		if ($imagesSortOrder === "descending") {
@@ -48,7 +63,7 @@ function ListImages() {
 	}
 
 	if (count($images) == 0) {
-		DisplayImageError("Displaying images", "There are no images for $chosen_day");		
+		DisplayImageError("Displaying images", "There are no images for $chosen_day$title_suffix");		
 	}
 
 	$width = getVariableOrDefault($settings_array, 'thumbnailsizex', 100);
@@ -57,8 +72,8 @@ function ListImages() {
 	echo '<div id="lightgallery">';
 	foreach ($images as $image) {
 
-    echo "<a href='/images/$chosen_day/$image' data-lg-size='1600-2400'>";
-    echo "    <img alt='$image' width=$width height=$height src='/images/$chosen_day/thumbnails/$image' loading='lazy' decoding='async' fetchpriority='low' />";
+    echo "<a href='$web_path/$image' data-lg-size='1600-2400'>";
+    echo "    <img alt='$image' width=$width height=$height src='$web_path/thumbnails/$image' loading='lazy' decoding='async' fetchpriority='low' />";
     echo '</a>';
 
 	}


### PR DESCRIPTION
This pull request introduces support for archiving and uploading daily images into a date-based directory structure (`images/YYYY/YYYYMMDD/`), along with user interface improvements for browsing these archived images. It adds configuration options, updates backend logic to handle uploads and queueing, and enhances the website UI to make archived images easily accessible.

### Features
- Instant image upload: Upload images directly from ramfs after each capture (respects "Upload Every X Images" frequency setting)
- Retry Queue: Failed uploads are queued in RAMFS and retried on subsequent captures
- Web Gallery: PHP-based gallery at `html/allsky/images/` with calendar navigation and thumbnail support
- Archive Integration: Archive icon in days view shows when archived images are available
- New option `uploadimages` in Settings > Timelapse panel:
  - Default: `false`
  - Uploads to: `images/YYYY/YYYYMMDD/image-YYYYMMDD_HHMMSS.jpg`
  - Depends on: Local Website, Remote Website, or Remote Server being enabled

### Technical Details
- Images uploaded from RAMFS (`${ALLSKY_TMP}`) to avoid SD card writes
- Queue stored at `${ALLSKY_TMP}/image_upload_queue/YYYY/YYYYMMDD/`
- Gallery supports date html attribute `?date=YYYYMMDD`


### Live deployment:
https://space.astro.cz/meteo/sutiny/allsky/images/

<img width="1417" height="629" alt="image" src="https://github.com/user-attachments/assets/18cc94ee-5a70-4e23-adfd-ce12456676bf" />



**The next step** is to use a JavaScript library that allows scrolling between images using arrow keys. This should also be implemented for keograms and star trails. It will be in following PR because it is related to multiple parts of sw stack. 
