### PR TITLE
Allsky external icon

### DIFF
--- a/html/includes/uiutil.php
+++ b/html/includes/uiutil.php
@@ -100,7 +100,7 @@ class UIUTIL extends UTILBASE {
      * @param float|int   $max              Upper bound for clamping
      * @param float|int   $danger           Threshold for red (>=)
      * @param float|int   $warning          Threshold for yellow (>=)
-     * @param string      $status_override  Force bar state ('success'|'warning'|'danger'|_)
+     * @param string      $status_override  Force bar state ('success'|'warning'|'danger'|...)
      *
      * @return string HTML <div> for a progress-bar-* element
      */
@@ -186,7 +186,7 @@ class UIUTIL extends UTILBASE {
         ]);
     }
 
-    /** CPU load as a percentage progress bar (green+yellow+red) */
+    /** CPU load as a percentage progress bar (green->yellow->red) */
     public function getCPULoad()
     {
         $cpuLoad = (float)getCPULoad(1);
@@ -356,8 +356,8 @@ class UIUTIL extends UTILBASE {
      *
      * Response:
      * {
-     *   "CPULoad": "<div class='progress-bar _'>_</div>",
-     *   "CPUTemp": "<div class='progress-bar _'>_</div>",
+     *   "CPULoad": "<div class='progress-bar ...'>...</div>",
+     *   "CPUTemp": "<div class='progress-bar ...'>...</div>",
      *   "Uptime":  "1 day 02:33:10"
      * }
      *

--- a/html/includes/uiutil.php
+++ b/html/includes/uiutil.php
@@ -100,7 +100,7 @@ class UIUTIL extends UTILBASE {
      * @param float|int   $max              Upper bound for clamping
      * @param float|int   $danger           Threshold for red (>=)
      * @param float|int   $warning          Threshold for yellow (>=)
-     * @param string      $status_override  Force bar state ('success'|'warning'|'danger'|…)
+     * @param string      $status_override  Force bar state ('success'|'warning'|'danger'|_)
      *
      * @return string HTML <div> for a progress-bar-* element
      */
@@ -138,10 +138,10 @@ class UIUTIL extends UTILBASE {
         $remoteWebsiteBadgeText = $useRemoteWebsite ? 'Enabled' : 'Disabled';
         $remoteWebsiteVersion = $this->getRemoteWebsiteVersionText();
         $localWebsiteLink = $useLocalWebsite
-            ? "<a external='true' target='_blank' rel='noopener noreferrer' href='allsky/index.php'>View</a>"
+            ? "<a external='true' target='_blank' rel='noopener noreferrer' href='allsky/index.php'>View " . ALLSKY_EXTERNAL_ICON . "</a>"
             : "";
         $remoteWebsiteLink = $useRemoteWebsite
-            ? "<a external='true' target='_blank' rel='noopener noreferrer' href='{$remoteWebsiteURL}'>View {$remoteWebsiteVersion}</a>"
+            ? "<a external='true' target='_blank' rel='noopener noreferrer' href='{$remoteWebsiteURL}'>View {$remoteWebsiteVersion} " .ALLSKY_EXTERNAL_ICON . "</a>"
             : "";
         $websiteHtml = "<div class='header-status-row'><span class='header-status-row-label'>Local:</span><span class='header-status-row-value'><span class='label {$localWebsiteBadgeClass}'>{$localWebsiteBadgeText}</span> {$localWebsiteLink}</span></div><div class='header-status-row'><span class='header-status-row-label'>Remote:</span><span class='header-status-row-value'><span class='label {$remoteWebsiteBadgeClass}'>{$remoteWebsiteBadgeText}</span> {$remoteWebsiteLink}</span></div>";
 
@@ -186,7 +186,7 @@ class UIUTIL extends UTILBASE {
         ]);
     }
 
-    /** CPU load as a percentage progress bar (green→yellow→red) */
+    /** CPU load as a percentage progress bar (green+yellow+red) */
     public function getCPULoad()
     {
         $cpuLoad = (float)getCPULoad(1);
@@ -356,8 +356,8 @@ class UIUTIL extends UTILBASE {
      *
      * Response:
      * {
-     *   "CPULoad": "<div class='progress-bar …'>…</div>",
-     *   "CPUTemp": "<div class='progress-bar …'>…</div>",
+     *   "CPULoad": "<div class='progress-bar _'>_</div>",
+     *   "CPUTemp": "<div class='progress-bar _'>_</div>",
      *   "Uptime":  "1 day 02:33:10"
      * }
      *

--- a/html/index.php
+++ b/html/index.php
@@ -223,13 +223,13 @@ $pageInfo = [
 	"documentation" => [
 		"title" => "Allsky Documentation",
 		"icon" => "fa fa-book fa-fw",
-		"icon2" => ALLSKY_EXTERNAL_ICON,
+		"external" => "true",
 		"href" => "/docs'",
 	],
 	"mini_timelapse" => [
 		"title" => "View Mini-Timelapse",
 		"icon" => "fa fa-file-video fa-fw",
-		"icon2" => ALLSKY_EXTERNAL_ICON,
+		"external" => "true",
 		"href" => ALLSKY_MINITIMELAPSE_URL
 	],
 	"notFound" => [
@@ -267,10 +267,10 @@ function getPageIcon($p) {
 
 	return $pageInfo[$p]['icon'] ?? "";
 }
-function getPageIcon2($p) {
+function getExternal($p) {
 	global $pageInfo;
 
-	return $pageInfo[$p]['icon2'] ?? "";
+	return $pageInfo[$p]['external'] ?? "false";
 }
 function getPageHelp($p) {
 	global $pageInfo;
@@ -323,22 +323,29 @@ function insertHref($p, $day, $displayTitle=false, $iconImage="") {
 	if ($day !== "") $href .= "&day=$day";
 	if ($iconImage === "") {
 		$icon = getPageIcon($p);
-		$icon2 = getPageIcon2($p);
+		$external = getExternal($p);
 	} else {
 		$icon = $iconImage;
-		$icon2 = "";
+		$external = "false";
 	}
 	if ($icon === "") {
 		echo "<span style='color: red' title='$title'>???</span>";
 	} else {
-		echo "<a id='$p' href='$href' title='$title'>";
+		if ($external === "true") {
+			$target = "target='_blank'";
+		} else {
+			$target = "";
+		}
+		echo "<a id='$p' href='$href' title='$title' $target>";
 		if ($iconImage === "") {
 			echo "<i class='$icon'></i>";
 		} else {
 			echo $iconImage;
 		}
 		if ($displayTitle) echo " $title";
-		if ($icon2 !== "") echo $icon2;
+		if ($external === "true") {
+			echo " " . ALLSKY_EXTERNAL_ICON;
+		}
 		echo "</a>";
 	}
 }
@@ -354,7 +361,7 @@ function insertMenuItem($p, $day, $type="", $href_only=false) {
 
 	$title = getPageTitle($p, $day);
 	$icon = getPageIcon($p);
-	$icon2 = getPageIcon2($p);
+	$external = getExternal($p);
 	$href = getVariableOrDefault($t, "href", "index.php?page=$p");
 	$jsHandler = getJSHandler($p);
 	$extraCSS = getextraCss($p);
@@ -370,7 +377,9 @@ function insertMenuItem($p, $day, $type="", $href_only=false) {
 		if ($type !== "dropdown") echo "<span class='menu-text'>";
 		echo " $title";
 		if ($type !== "dropdown") echo "</span>";
-		if ($icon2 !== "") echo $icon2;
+		if ($external === "true") {
+			echo " " . ALLSKY_EXTERNAL_ICON;
+		}
 		echo "</a>";
 		echo "</li>\n";
 	} else {
@@ -379,7 +388,9 @@ function insertMenuItem($p, $day, $type="", $href_only=false) {
 		echo "<li>";
 		echo "<a id='$p' href='$href' class='allsky-js-handler' data-jsclass='$jsHandler'><i class='$icon $extraiconcss'></i>";
 		echo "<span class='menu-text $extratextcss'>$title</span>";
-		if ($icon2 !== "") echo $icon2;
+		if ($external === "true") {
+			echo " " . ALLSKY_EXTERNAL_ICON;
+		}
 		echo "</a>";
 		echo "</li>\n";
 	}

--- a/html/index.php
+++ b/html/index.php
@@ -223,12 +223,14 @@ $pageInfo = [
 	"documentation" => [
 		"title" => "Allsky Documentation",
 		"icon" => "fa fa-book fa-fw",
+		"icon2" => ALLSKY_EXTERNAL_ICON,
 		"href" => "/docs'",
 	],
 	"mini_timelapse" => [
 		"title" => "View Mini-Timelapse",
 		"icon" => "fa fa-file-video fa-fw",
-		"href" => ALLSKY_MINITIMELAPSE_URL . "' external='true'"
+		"icon2" => ALLSKY_EXTERNAL_ICON,
+		"href" => ALLSKY_MINITIMELAPSE_URL
 	],
 	"notFound" => [
 		"headerTitle" => "Unknown page - contact Allsky support",
@@ -264,6 +266,11 @@ function getPageIcon($p) {
 	global $pageInfo;
 
 	return $pageInfo[$p]['icon'] ?? "";
+}
+function getPageIcon2($p) {
+	global $pageInfo;
+
+	return $pageInfo[$p]['icon2'] ?? "";
 }
 function getPageHelp($p) {
 	global $pageInfo;
@@ -316,8 +323,10 @@ function insertHref($p, $day, $displayTitle=false, $iconImage="") {
 	if ($day !== "") $href .= "&day=$day";
 	if ($iconImage === "") {
 		$icon = getPageIcon($p);
+		$icon2 = getPageIcon2($p);
 	} else {
 		$icon = $iconImage;
+		$icon2 = "";
 	}
 	if ($icon === "") {
 		echo "<span style='color: red' title='$title'>???</span>";
@@ -329,6 +338,7 @@ function insertHref($p, $day, $displayTitle=false, $iconImage="") {
 			echo $iconImage;
 		}
 		if ($displayTitle) echo " $title";
+		if ($icon2 !== "") echo $icon2;
 		echo "</a>";
 	}
 }
@@ -344,6 +354,7 @@ function insertMenuItem($p, $day, $type="", $href_only=false) {
 
 	$title = getPageTitle($p, $day);
 	$icon = getPageIcon($p);
+	$icon2 = getPageIcon2($p);
 	$href = getVariableOrDefault($t, "href", "index.php?page=$p");
 	$jsHandler = getJSHandler($p);
 	$extraCSS = getextraCss($p);
@@ -359,6 +370,7 @@ function insertMenuItem($p, $day, $type="", $href_only=false) {
 		if ($type !== "dropdown") echo "<span class='menu-text'>";
 		echo " $title";
 		if ($type !== "dropdown") echo "</span>";
+		if ($icon2 !== "") echo $icon2;
 		echo "</a>";
 		echo "</li>\n";
 	} else {
@@ -367,6 +379,7 @@ function insertMenuItem($p, $day, $type="", $href_only=false) {
 		echo "<li>";
 		echo "<a id='$p' href='$href' class='allsky-js-handler' data-jsclass='$jsHandler'><i class='$icon $extraiconcss'></i>";
 		echo "<span class='menu-text $extratextcss'>$title</span>";
+		if ($icon2 !== "") echo $icon2;
 		echo "</a>";
 		echo "</li>\n";
 	}


### PR DESCRIPTION
Alex, the old  "<a external='true' ...>" no longer works.  It used /html/documentation/js/documentation.js which no longer exists.
That script added the "external" icon, "target=_blank", and "title='Opens in new tab/window'" to any <a> that had "external='true'".

With the new code that uses json arrays, I don't think the old documentation.json will work since it ran once when the page loaded.

The new ALLSKY_EXTERNAL_ICON is that "external" icon (a box with an arrow pointing up and to the right), which indicates a new tab will be created.
Adding '"external" : 'true'" to the array of pages does what the old "external='true'" did (except for adding "title='Opens in new tab/window'" since you use "title=" for other things.

Let me know what you think.