### PR TITLE
Chnage to the way external icons are handled

### DIFF
--- a/html/css/allsky.css
+++ b/html/css/allsky.css
@@ -1312,6 +1312,16 @@ input, textarea, select, [contenteditable="true"], .allow-select, .allow-select 
   user-select: text !important;
 }
 
+a[external="true"]::after {
+    font-family: "Font Awesome 6 Free";
+    content: "\f35d";
+    font-weight: 900;
+    margin-left: 6px;
+    font-size: 0.85em;
+    vertical-align: middle;
+    opacity: 0.7;
+}
+
 .panel-body .row {
     margin: 0;
 }

--- a/html/includes/systembuttonsutil.php
+++ b/html/includes/systembuttonsutil.php
@@ -41,7 +41,11 @@ class SYSTEMBUTTONSUTIL extends UTILBASE
 
     private function getConfigDirectory(): string
     {
-        return rtrim(ALLSKY_CONFIG, '/');
+        if (defined('ALLSKY_MYFILES_DIR')) {
+            return rtrim(ALLSKY_MYFILES_DIR, '/');
+        }
+
+        return rtrim(ALLSKY_CONFIG, '/') . '/myFiles';
     }
 
     private function isWithinConfigDirectory(string $path): bool
@@ -79,7 +83,7 @@ class SYSTEMBUTTONSUTIL extends UTILBASE
 
         $normalizedPath = rtrim($directory, '/') . '/' . basename($path);
         if (!$this->isWithinConfigDirectory($normalizedPath)) {
-            $this->send400('System Page Additions files must be stored in ~/allsky/config.');
+            $this->send400('System Page Additions files must be stored in ~/allsky/config/myFiles.');
         }
 
         return $normalizedPath;
@@ -106,7 +110,7 @@ class SYSTEMBUTTONSUTIL extends UTILBASE
         }
 
         if (!$this->isWithinConfigDirectory($realPath)) {
-            $this->send403('You can only browse files in ~/allsky/config.');
+            $this->send403('You can only browse files in ~/allsky/config/myFiles.');
         }
 
         return $realPath;
@@ -194,7 +198,7 @@ class SYSTEMBUTTONSUTIL extends UTILBASE
     private function buildWritableError(string $path, string $targetType): string
     {
         return sprintf(
-            '%s "%s" is not writable by the WebUI user. System Page Additions files must be stored in the ~/allsky/config folder.',
+            '%s "%s" is not writable by the WebUI user. System Page Additions files must be stored in the ~/allsky/config/myFiles folder.',
             ucfirst($targetType),
             $path
         );
@@ -701,7 +705,7 @@ class SYSTEMBUTTONSUTIL extends UTILBASE
                     'path' => $realPath,
                     'type' => 'directory',
                 ];
-            } elseif (is_file($realPath)) {
+            } elseif (is_file($realPath) && strcasecmp(pathinfo($item, PATHINFO_EXTENSION), 'txt') === 0) {
                 $files[] = [
                     'name' => $item,
                     'path' => $realPath,

--- a/html/includes/uiutil.php
+++ b/html/includes/uiutil.php
@@ -138,10 +138,10 @@ class UIUTIL extends UTILBASE {
         $remoteWebsiteBadgeText = $useRemoteWebsite ? 'Enabled' : 'Disabled';
         $remoteWebsiteVersion = $this->getRemoteWebsiteVersionText();
         $localWebsiteLink = $useLocalWebsite
-            ? "<a external='true' target='_blank' rel='noopener noreferrer' href='allsky/index.php'>View " . ALLSKY_EXTERNAL_ICON . "</a>"
+            ? "<a external='true' target='_blank' rel='noopener noreferrer' href='allsky/index.php'>View</a>"
             : "";
         $remoteWebsiteLink = $useRemoteWebsite
-            ? "<a external='true' target='_blank' rel='noopener noreferrer' href='{$remoteWebsiteURL}'>View {$remoteWebsiteVersion} " .ALLSKY_EXTERNAL_ICON . "</a>"
+            ? "<a external='true' target='_blank' rel='noopener noreferrer' href='{$remoteWebsiteURL}'>View {$remoteWebsiteVersion}</a>"
             : "";
         $websiteHtml = "<div class='header-status-row'><span class='header-status-row-label'>Local:</span><span class='header-status-row-value'><span class='label {$localWebsiteBadgeClass}'>{$localWebsiteBadgeText}</span> {$localWebsiteLink}</span></div><div class='header-status-row'><span class='header-status-row-label'>Remote:</span><span class='header-status-row-value'><span class='label {$remoteWebsiteBadgeClass}'>{$remoteWebsiteBadgeText}</span> {$remoteWebsiteLink}</span></div>";
 

--- a/html/index.php
+++ b/html/index.php
@@ -319,6 +319,13 @@ function insertHref($p, $day, $displayTitle=false, $iconImage="") {
 		if ($AllTitle !== null)
 			$title = $AllTitle;
 	}
+
+	$external = getExternal($p);	
+	$external_attr = "";
+	if ($external === "true") {
+		$external_attr = 'external="true"';
+	}
+
 	$href = getVariableOrDefault($t, "href", "index.php?page=$p");
 	if ($day !== "") $href .= "&day=$day";
 	if ($iconImage === "") {
@@ -336,16 +343,13 @@ function insertHref($p, $day, $displayTitle=false, $iconImage="") {
 		} else {
 			$target = "";
 		}
-		echo "<a id='$p' href='$href' title='$title' $target>";
+		echo "<a id='$p' $external_attr href='$href' title='$title' $target>";
 		if ($iconImage === "") {
 			echo "<i class='$icon'></i>";
 		} else {
 			echo $iconImage;
 		}
 		if ($displayTitle) echo " $title";
-		if ($external === "true") {
-			echo " " . ALLSKY_EXTERNAL_ICON;
-		}
 		echo "</a>";
 	}
 }
@@ -371,26 +375,26 @@ function insertMenuItem($p, $day, $type="", $href_only=false) {
 		$target = ' target="_blank" rel="noopener noreferrer"';
 	}
 
+	$external_attr = "";
+	if ($external === "true") {
+		$external_attr = 'external="true"';
+	}
+
 	if ($jsHandler === null) {
 		echo "<li>";
-		echo "<a id='$p' href='$href' $target><i class='$icon'></i>";
+		echo "<a id='$p' $external_attr href='$href' $target><i class='$icon'></i>";
 		if ($type !== "dropdown") echo "<span class='menu-text'>";
 		echo " $title";
 		if ($type !== "dropdown") echo "</span>";
-		if ($external === "true") {
-			echo " " . ALLSKY_EXTERNAL_ICON;
-		}
 		echo "</a>";
 		echo "</li>\n";
 	} else {
 		$extraiconcss = $extraCSS["extraiconcss"];
 		$extratextcss = $extraCSS["extratextcss"];
 		echo "<li>";
-		echo "<a id='$p' href='$href' class='allsky-js-handler' data-jsclass='$jsHandler'><i class='$icon $extraiconcss'></i>";
+		echo "<a id='$p' $external_attr href='$href' class='allsky-js-handler' data-jsclass='$jsHandler'><i class='$icon $extraiconcss'></i>";
 		echo "<span class='menu-text $extratextcss'>$title</span>";
-		if ($external === "true") {
-			echo " " . ALLSKY_EXTERNAL_ICON;
-		}
+
 		echo "</a>";
 		echo "</li>\n";
 	}

--- a/html/js/allsky.js
+++ b/html/js/allsky.js
@@ -106,6 +106,8 @@ class ALLSKY {
 				}
 			} catch (e) {
 			}
+
+			$('a[external="true"]').attr('target', '_blank');
 		});
 
 	}
@@ -169,6 +171,10 @@ class ALLSKY {
 		this.#addTimestamp('system');
 		this.#addTimestamp('auth_conf');
 		this.#addTimestamp('support');
+	}
+
+	#setupExternalLinks() {
+		$('a[external="true"]').attr('target', '_blank');
 	}
 
 	#initTimers(page) {
@@ -540,6 +546,7 @@ class ALLSKY {
 	init() {
 		this.#setupTheme();
 		this.#setupBigScreen();
+		this.#setupExternalLinks();
 		this.#setupTimestamps();
 		// initialize timers that apply to all pages
 		this.#initTimers('all');

--- a/html/js/jquery-systempagebuttons/jquery-systempagebuttons.js
+++ b/html/js/jquery-systempagebuttons/jquery-systempagebuttons.js
@@ -6,7 +6,7 @@
             this.$trigger = $(element);
             this.files = [];
             this.configuredFiles = [];
-            this.configDir = "/home/pi/allsky/config";
+            this.configDir = "";
             this.activePath = "";
             this.editIndex = -1;
             this.$modal = null;
@@ -203,7 +203,7 @@
                                         <div class="form-group">
                                             <div class="row">
                                                 <div class="col-sm-8">
-                                                    <label>Browse Files In ~/allsky/config</label>
+                                                    <label>Browse Files In ~/allsky/config/myFiles</label>
                                                     <div class="help-block" id="as-system-entries-browser-root" style="margin-top: 0; margin-bottom: 0;"></div>
                                                 </div>
                                                 <div class="col-sm-4 text-right" style="padding-top: 22px;">
@@ -224,10 +224,10 @@
                                         <div class="form-group">
                                             <label for="as-system-entries-new-path">Filename</label>
                                             <div class="input-group">
-                                                <span class="input-group-addon" id="as-system-entries-new-prefix">~/allsky/config/</span>
+                                                <span class="input-group-addon" id="as-system-entries-new-prefix">~/allsky/config/myFiles/</span>
                                                 <input type="text" id="as-system-entries-new-path" class="form-control" placeholder="my_buttons.txt">
                                             </div>
-                                            <div class="help-block" style="margin-bottom: 0;">New additions files are always stored in <code>~/allsky/config</code>.</div>
+                                            <div class="help-block" style="margin-bottom: 0;">New additions files are always stored in <code>~/allsky/config/myFiles</code> and saved with a <code>.txt</code> extension.</div>
                                         </div>
                                     </div>
                                 </div>
@@ -258,7 +258,7 @@
             this.$browserModal.on("click", "#as-system-entries-browser-create-footer", () => {
                 const fileName = $.trim(this.$browserModal.find("#as-system-entries-new-path").val() || "");
                 if (fileName === "") {
-                    this.setMessage("Enter the filename you want to create in ~/allsky/config.");
+                    this.setMessage("Enter the filename you want to create in ~/allsky/config/myFiles.");
                     return;
                 }
                 const path = this.buildConfigFilePath(fileName);
@@ -705,7 +705,7 @@
         }
 
         browseDirectory(path) {
-            const browsePath = $.trim(path || this.configDir || "/home/pi/allsky/config");
+            const browsePath = $.trim(path || this.configDir || "");
             this.$browserList.html('<div class="list-group-item text-muted">Loading...</div>');
 
             $.ajax({
@@ -747,7 +747,7 @@
         openBrowser(mode) {
             this.ensureBrowserModal();
             this.renderConfiguredFileList();
-            const browsePath = this.configDir;
+            const browsePath = this.configDir || "";
             const $openPanel = this.$browserModal.find(".as-system-entries-open-panel");
             const $newPanel = this.$browserModal.find(".as-system-entries-new-panel");
             const $title = this.$browserModal.find("#as-system-entries-browser-title");
@@ -793,7 +793,7 @@
         }
 
         buildConfigFilePath(fileName) {
-            const safeName = fileName.replace(/^\/+/, "");
+            const safeName = fileName.replace(/^\/+/, "").replace(/\.txt$/i, "") + ".txt";
             return `${this.configDir}/${safeName}`;
         }
 


### PR DESCRIPTION
Slight change to the way external icons are handled

1) Uses css to ensure that any elements with external="true" have the icon added after
2) Ensures that all elements with external="true" have target="_blank" attribute. This is applied on page load and for ajax requests in allsky.js
3) The external flag in index.php is retained

This removes the need for any code to handle the adding of the external icon.