### PR TITLE
#5161 Force download of legacy TLE element format

### DIFF
--- a/scripts/modules/allsky_overlay.py
+++ b/scripts/modules/allsky_overlay.py
@@ -1315,7 +1315,7 @@ class ALLSKYOVERLAY:
             fileAge = 9999
 
         if fileAge > 2:
-            r = requests.get(f'https://celestrak.org/NORAD/elements/gp.php?CATNR={noradCatId}', verify=verify, timeout=5)
+            r = requests.get(f'https://celestrak.org/NORAD/elements/gp.php?CATNR={noradCatId}&FORMAT=TLE', verify=verify, timeout=5)
             r.raise_for_status()
 
             if r.text == 'No GP data found':


### PR DESCRIPTION
Celestrak have switched the default element data from TLE to their new format, this is to facilitate the ever increasing number of objects in orbit

The old format was

```
ISS (ZARYA)
1 25544U 98067A   26133.42450843  .00004829  00000+0  95080-4 0  9993
2 25544  51.6310 112.1825 0007522  54.1994 305.9693 15.49203550566361
```

The new format is

```
OBJECT_NAME,OBJECT_ID,EPOCH,MEAN_MOTION,ECCENTRICITY,INCLINATION,RA_OF_ASC_NODE,ARG_OF_PERICENTER,MEAN_ANOMALY,EPHEMERIS_TYPE,CLASSIFICATION_TYPE,NORAD_CAT_ID,ELEMENT_SET_NO,REV_AT_EPOCH,BSTAR,MEAN_MOTION_DOT,MEAN_MOTION_DDOT
ISS (ZARYA),1998-067A,2026-05-13T10:11:17.528352,15.49203550,.0007522,51.6310,112.1825,54.1994,305.9693,0,U,25544,999,56636,.9508E-4,.4829E-4,0
```

The fix for this branch is to append &FORMAT=TLE to the request to force a download of the legacy format